### PR TITLE
initialize friends variables on friends element creation

### DIFF
--- a/modules/infotext/friends.lua
+++ b/modules/infotext/friends.lua
@@ -630,6 +630,7 @@ end
 
 function element:OnCreate()
 	element:AddUpdate(C_FriendList.ShowFriends, FRIENDS_UPDATE_TIME)
+	element:FriendlistUpdate()
 	element:RegisterEvent("FRIENDLIST_UPDATE", "FriendlistUpdate")
 	C_FriendList.ShowFriends()
 


### PR DESCRIPTION
FRIENDLIST_UPDATE event doesn't fire on login anymore, which leaves the friends element variables uninitialized.

Seems that the update is now fired only on:
- adding/removing a friend
- friend going online/offline