### PR TITLE
Fix additional WoW 12.0.1 Lua errors

### DIFF
--- a/api/modapi.lua
+++ b/api/modapi.lua
@@ -34,8 +34,8 @@ end
 ---@return number R, number G, number B
 function ModuleMixin:RGB(colorName)
 	if not colorName or issecretvalue(colorName) then
-		return
-	end
+	return 1, 1, 1
+end
 	local db = self:GetDB("Colors")
 	if db and db[colorName] then
 		-- TODO: Check for all planned types (.t)

--- a/api/modapi.lua
+++ b/api/modapi.lua
@@ -33,7 +33,9 @@ end
 ---@param colorName string @ check module db first, then color module.
 ---@return number R, number G, number B
 function ModuleMixin:RGB(colorName)
-	--  TODO: Fix the issue with RGB colors as RGBA colors in the options
+	if not colorName or issecretvalue(colorName) then
+		return
+	end
 	local db = self:GetDB("Colors")
 	if db and db[colorName] then
 		-- TODO: Check for all planned types (.t)

--- a/modules/expbars/expbars.lua
+++ b/modules/expbars/expbars.lua
@@ -259,7 +259,11 @@ end
 
 function module:UpdateMainBarVisibility()
 	local barLeft, barRight
-
+	if not module.ExperienceBar or not module.ReputationBar
+		or not module.HonorBar or not module.AzeriteBar
+		or not module.GenesisBar then
+		return
+	end
 	-- Check which bars can be visible at the moment
 	local expShown = module.ExperienceBar:ShouldBeVisible()
 	local repShown = module.ReputationBar:ShouldBeVisible()


### PR DESCRIPTION
Fixes two additional WoW 12.0.1 compatibility issues.

Changes:
- Prevent secret color values from being used as module color table keys
- Prevent Experience Bar visibility updates before the bars are initialized

Reported errors:
- LUI/api/modapi.lua: attempted to index a table that cannot be indexed with secret keys
- LUI/modules/expbars/expbars.lua: attempt to index field 'ExperienceBar' (a nil value)