### PR TITLE
Fix secret value errors in oUF elements

### DIFF
--- a/api/oUF13/elements/auras.lua
+++ b/api/oUF13/elements/auras.lua
@@ -293,6 +293,18 @@ local function processData(element, unit, data, filter)
 	return data
 end
 
+local function GetAuraSlotsSafe(unit, filter)
+	local success, slots = pcall(function()
+		return {C_UnitAuras.GetAuraSlots(unit, filter)}
+	end)
+
+	if not success then
+		return
+	end
+
+	return slots
+end
+
 local function UpdateAuras(self, event, unit, updateInfo)
 	if(self.unit ~= unit) then return end
 
@@ -335,7 +347,8 @@ end
 			auras.activeBuffs = table.wipe(auras.activeBuffs or {})
 			buffsChanged = true
 
-			local slots = {C_UnitAuras.GetAuraSlots(unit, buffFilter)}
+			local slots = GetAuraSlotsSafe(unit, buffFilter)
+			if not slots then return end
 			for i = 2, #slots do -- #1 return is continuationToken, we don't care about it
 				local data = processData(auras, unit, C_UnitAuras.GetAuraDataBySlot(unit, slots[i]), buffFilter)
 				auras.allBuffs[data.auraInstanceID] = data
@@ -361,7 +374,8 @@ end
 			auras.activeDebuffs = table.wipe(auras.activeDebuffs or {})
 			debuffsChanged = true
 
-			slots = {C_UnitAuras.GetAuraSlots(unit, debuffFilter)}
+			slots = GetAuraSlotsSafe(unit, debuffFilter)
+			if not slots then return end
 			for i = 2, #slots do
 				local data = processData(auras, unit, C_UnitAuras.GetAuraDataBySlot(unit, slots[i]), debuffFilter)
 				auras.allDebuffs[data.auraInstanceID] = data
@@ -606,13 +620,8 @@ end
 			buffs.active = table.wipe(buffs.active or {})
 			buffsChanged = true
 
-			local success, slots = pcall(function()
-	return {C_UnitAuras.GetAuraSlots(unit, buffFilter)}
-end)
-
-if not success then
-	return
-end
+			local slots = GetAuraSlotsSafe(unit, buffFilter)
+			if not slots then return end
 			for i = 2, #slots do
 				local data = processData(buffs, unit, C_UnitAuras.GetAuraDataBySlot(unit, slots[i]), buffFilter)
 				buffs.all[data.auraInstanceID] = data
@@ -723,8 +732,9 @@ end
 			debuffs.all = table.wipe(debuffs.all or {})
 			debuffs.active = table.wipe(debuffs.active or {})
 			debuffsChanged = true
-
-			local slots = {C_UnitAuras.GetAuraSlots(unit, debuffFilter)}
+			
+			local slots = GetAuraSlotsSafe(unit, debuffFilter)
+			if not slots then return end
 			for i = 2, #slots do
 				local data = processData(debuffs, unit, C_UnitAuras.GetAuraDataBySlot(unit, slots[i]), debuffFilter)
 				debuffs.all[data.auraInstanceID] = data

--- a/api/oUF13/elements/grouproleindicator.lua
+++ b/api/oUF13/elements/grouproleindicator.lua
@@ -42,6 +42,11 @@ local function Update(self, event)
 	end
 
 	local role = UnitGroupRolesAssigned(self.unit)
+	if issecretvalue(role) then
+		element:Hide()
+		return
+	end
+	
 	if(role == 'TANK') then
 		element:SetAtlas('UI-LFG-RoleIcon-Tank-Micro-Raid', element.useAtlasSize)
 		element:Show()

--- a/api/oUF13/elements/leaderindicator.lua
+++ b/api/oUF13/elements/leaderindicator.lua
@@ -59,6 +59,11 @@ local function Update(self, event)
 		isLeader = UnitLeadsAnyGroup(unit)
 	end
 
+	if issecretvalue(isLeader) then
+		element:Hide()
+		return
+	end
+	
 	if(isLeader) then
 		if(isInLFGInstance) then
 			element:SetAtlas('UI-HUD-UnitFrame-Player-Group-GuideIcon', element.useAtlasSize)


### PR DESCRIPTION
Fixes several oUF errors caused by WoW secret value restrictions.

- Safely handles restricted `GetAuraSlots()` calls
- Handles secret group role values
- Handles secret group leader values

Prevents repeated Lua errors while keeping the existing oUF13 implementation intact.
