### PR TITLE
Fix secret values in group indicators

### DIFF
--- a/api/oUF13/elements/grouproleindicator.lua
+++ b/api/oUF13/elements/grouproleindicator.lua
@@ -42,6 +42,12 @@ local function Update(self, event)
 	end
 
 	local role = UnitGroupRolesAssigned(self.unit)
+
+	if issecretvalue(role) then
+		element:Hide()
+		return
+	end
+	
 	if(role == 'TANK') then
 		element:SetAtlas('UI-LFG-RoleIcon-Tank-Micro-Raid', element.useAtlasSize)
 		element:Show()

--- a/api/oUF13/elements/leaderindicator.lua
+++ b/api/oUF13/elements/leaderindicator.lua
@@ -59,17 +59,14 @@ local function Update(self, event)
 		isLeader = UnitLeadsAnyGroup(unit)
 	end
 
-	if(isLeader) then
-		if(isInLFGInstance) then
-			element:SetAtlas('UI-HUD-UnitFrame-Player-Group-GuideIcon', element.useAtlasSize)
-		else
-			element:SetAtlas('UI-HUD-UnitFrame-Player-Group-LeaderIcon', element.useAtlasSize)
-		end
-
-		element:Show()
+	if(isInLFGInstance) then
+		element:SetAtlas('UI-HUD-UnitFrame-Player-Group-GuideIcon', element.useAtlasSize)
 	else
-		element:Hide()
+		element:SetAtlas('UI-HUD-UnitFrame-Player-Group-LeaderIcon', element.useAtlasSize)
 	end
+
+	element:Show()
+	element:SetAlphaFromBoolean(isLeader, 1, 0)
 
 	--[[ Callback: LeaderIndicator:PostUpdate(isLeader)
 	Called after the element has been updated.


### PR DESCRIPTION
- Handle secret boolean values in LeaderIndicator without direct boolean testing
- Use SetAlphaFromBoolean to control LeaderIndicator visibility
- Handle secret role values in GroupRoleIndicator before comparing role strings
- Prevent taint errors on target frames caused by secret leader and group role values

Tested locally; both reported errors no longer occur.