### PR TITLE
Fix Deathknight rune color handling

### DIFF
--- a/api/oUF13/elements/runes.lua
+++ b/api/oUF13/elements/runes.lua
@@ -86,10 +86,20 @@ local function UpdateColor(self, event)
 	end
 
 	if(color) then
+	local r, g, b
+
+	if(color.GetRGB) then
+		r, g, b = color:GetRGB()
+	else
+		r, g, b = color.r, color.g, color.b
+	end
+
+	if(r and g and b) then
 		for index = 1, #element do
-			element[index]:SetStatusBarColor(color:GetRGB())
+			element[index]:SetStatusBarColor(r, g, b)
 		end
 	end
+end
 
 	--[[ Callback: Runes:PostUpdateColor(color)
 	Called after the element color has been updated.


### PR DESCRIPTION
Adds a fallback for rune colors that do not provide GetRGB(), preventing the nil function error while keeping rune coloring intact.