### PR TITLE
Fix target debuff display with new AuraContainer API

### DIFF
--- a/api/oUF13/elements/auras.lua
+++ b/api/oUF13/elements/auras.lua
@@ -717,7 +717,7 @@ local function UpdateAuras(self, event, unit, updateInfo)
 	end
 
 	local debuffs = self.Debuffs
-	if(debuffs) then
+	if(debuffs and not debuffs.hasDebuffGroup) then
 		isFullUpdate = debuffs.needFullUpdate or isFullUpdate
 		debuffs.needFullUpdate = false
 

--- a/modules/unitframes/layout/layout.lua
+++ b/modules/unitframes/layout/layout.lua
@@ -2154,6 +2154,12 @@ module.funcs = {
 		if not self.Debuffs.hasDebuffGroup then
 			self.Debuffs:AddAuraGroup("debuffs", "HARMFUL|PLAYER", {
 				maxFrameCount = oufdb.Aura.Debuffs.Num,
+				layout = {
+						elementWidth = oufdb.Aura.Debuffs.Size,
+						elementHeight = oufdb.Aura.Debuffs.Size,
+						elementSpacing = oufdb.Aura.Debuffs.Spacing,
+						lineSpacing = oufdb.Aura.Debuffs.Spacing,
+				},
 				initializeFrame = function(button)
 					button:SetSize(oufdb.Aura.Debuffs.Size, oufdb.Aura.Debuffs.Size)
 

--- a/modules/unitframes/layout/layout.lua
+++ b/modules/unitframes/layout/layout.lua
@@ -2181,7 +2181,7 @@ module.funcs = {
 		end
 
 		self.Debuffs:SetUnit(unit)
-
+		self.Debuffs:UpdateAllAuras()
 		for i = 1, #self.Debuffs do
 			local button = self.Debuffs[i]
 			if button and button:IsShown() then

--- a/modules/unitframes/layout/layout.lua
+++ b/modules/unitframes/layout/layout.lua
@@ -2144,13 +2144,37 @@ module.funcs = {
 		if not self.Buffs.anchoredButtons then self.Buffs.anchoredButtons = 0 end
 	end,
 	Debuffs = function(self, unit, oufdb)
-		if not self.Debuffs then self.Debuffs = CreateFrame("Frame", nil, self) end
+		if not self.Debuffs then self.Debuffs = CreateFrame("AuraContainer", nil, self, "CustomAuraContainerTemplate") end
 
 		self.Debuffs:SetHeight(oufdb.Aura.Debuffs.Size)
 		self.Debuffs:SetWidth(oufdb.Width)
 		self.Debuffs.size = oufdb.Aura.Debuffs.Size
 		self.Debuffs.spacing = oufdb.Aura.Debuffs.Spacing
 		self.Debuffs.num = oufdb.Aura.Debuffs.Num
+		if not self.Debuffs.hasDebuffGroup then
+			self.Debuffs:AddAuraGroup("debuffs", "HARMFUL|PLAYER", {
+				maxFrameCount = oufdb.Aura.Debuffs.Num,
+				initializeFrame = function(button)
+					button:SetSize(oufdb.Aura.Debuffs.Size, oufdb.Aura.Debuffs.Size)
+
+					local icon = button:CreateTexture(nil, "ARTWORK")
+					icon:SetAllPoints(button)
+					button:SetIcon(icon)
+
+					local cooldown = CreateFrame("Cooldown", nil, button, "CooldownFrameTemplate")
+					cooldown:SetAllPoints(button)
+					cooldown:SetHideCountdownNumbers(false)
+					cooldown:SetMinimumCountdownDuration(0)
+
+					button:SetDurationCooldown(cooldown)
+				end,
+			})
+
+			self.Debuffs.hasDebuffGroup = true
+		end
+
+		self.Debuffs:SetUnit(unit)
+		self.Debuffs:UpdateAllAuras()
 
 		for i = 1, #self.Debuffs do
 			local button = self.Debuffs[i]

--- a/modules/unitframes/layout/layout.lua
+++ b/modules/unitframes/layout/layout.lua
@@ -2171,6 +2171,7 @@ module.funcs = {
 					cooldown:SetAllPoints(button)
 					cooldown:SetHideCountdownNumbers(false)
 					cooldown:SetMinimumCountdownDuration(0)
+					cooldown:SetReverse(oufdb.Aura.Debuffs.CooldownReverse)
 
 					button:SetDurationCooldown(cooldown)
 				end,

--- a/modules/unitframes/layout/layout.lua
+++ b/modules/unitframes/layout/layout.lua
@@ -2181,7 +2181,6 @@ module.funcs = {
 		end
 
 		self.Debuffs:SetUnit(unit)
-		self.Debuffs:UpdateAllAuras()
 
 		for i = 1, #self.Debuffs do
 			local button = self.Debuffs[i]


### PR DESCRIPTION
Updates target debuff handling to use the new AuraContainer API.

- Restores player debuff/DoT display on target frames
- Restores duration cooldown display
- Adds size and spacing layout support
- Restores cooldown reverse setting
- Prevents the legacy oUF debuff path from processing the new AuraContainer

Further LUI debuff options still need to be adapted to the new AuraContainer API.