### PR TITLE
Fix bag styling and sorting, add optional bank support and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ This release updates LUI for World of Warcraft Retail 12.1 while keeping the ori
 - Added clear descriptions for sticky channels and hover-window font settings.
 - Updated Friends, Guild and the remaining infotext providers for the current APIs.
 - Clock: Kept the time display fixed by showing instance information separately. Added compact difficulty labels including N, HC, M, M+ and MFlex, while keeping the full instance name and difficulty available in the tooltip.
+- Fixed Clock initialization errors by using a fallback when the display font is not yet available.
+- Fixed Clock tooltip errors for saved instances with no localized difficulty name, keeping those lockouts visible in the tooltip.
+- Fixed Armor durability updates after portals and zone transitions by refreshing on world entry and player inventory changes. Unavailable durability now displays `--` instead of an incorrect 100%.
+- Prevented individual infotext initialization and settings errors from interrupting other displays. Errors remain reported, and incomplete displays can retry initialization when the panels are rebuilt.
 - Added background and border texture and color options for the Friends and Guild windows, matching the standard LUI tooltip defaults.
 - Corrected unit-tooltip guild colors so the player's guild is green and other guilds are blue.
 - Removed Blizzard's frame-settings hint from LUI player, party and raid frame tooltips.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This release updates LUI for World of Warcraft Retail 12.1 while keeping the ori
 
 ## Unit frames
 
+- Added optional raid-group text to the player frame, with position, font, size and color settings. It is disabled by default, stays empty outside raids and follows the player's subgroup through roster and vehicle changes using the existing oUF group tag.
+- Added separate group labels to LUI raid frames, enabled by default. Labels follow each group's layout, stay outside the unit frames and hide for empty groups. Text scales to fit the narrower 40-player columns; font, color and distance from the frames are configurable.
+- Included both displays in unit-frame previews: the player preview shows a sample group number, and the raid preview labels its group columns. Added their controls to both Compact and Categorized options.
 - Added optional absorb text to each unit frame, with live shield totals, short/full numbers, prefix, font, color, opacity, position and an option to hide zero values, including when shield values are protected.
 - Updated absorb bars to extend from the current health fill and overlap filled health when needed, keeping shields visible at full health. Added an overflow indicator for shields exceeding maximum health and preserved existing absorb display settings.
 - Kept unit-frame backgrounds, bars and indicators on consistent layers so world nameplates cannot appear between them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This release updates LUI for World of Warcraft Retail 12.1 while keeping the ori
 - Corrected visible border thickness for the bundled Stripped textures and supported Blizzard borders. Kept Details BarBorder 1 and 2 outlines stable as thickness changes, and adjusted Details BarBorder 3 sizing.
 - Applied item-quality colors to common and poor items and equipped bags. Empty item slots no longer show an item border, and native borders no longer overlap LUI borders.
 - Added Fill Bags from Bottom and kept its saved state in sync with Clean Bags. Reversed the displayed slots within each bag to remove gaps between partially filled and full bags, and deferred cleanup until the selected direction has updated.
+- Arranged newly looted items in the free area in both fill directions: from the top left when filling bags from the bottom, or from the bottom right when filling from the top. Existing items keep their displayed positions while looting; native stacking, bag filters and reagent restrictions remain in effect.
 - Refreshed bag layout, fonts, search opacity and colors from the active profile. Kept toolbar styling current after native bag-slot updates and restored separators in the gold display.
 
 ## Bank
@@ -74,6 +75,7 @@ This release updates LUI for World of Warcraft Retail 12.1 while keeping the ori
 
 ## Other fixes
 
+- Added an optional automatic reputation tracker that follows the last reported faction with a positive reputation gain, in either bar position or with separate bars. Reputation losses do not change the watched faction; the option is disabled by default.
 - Fixed Experience Bars retaining an old profile after profile changes, preventing missing-width errors and keeping layout, text and drag settings tied to the active profile.
 - Fixed Bags update handling and character-bag ownership.
 - Updated merchant coin-texture formatting to the current `C_CurrencyInfo` API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,23 @@ This release updates LUI for World of Warcraft Retail 12.1 while keeping the ori
 - Enabled texture category, preset and custom texture settings for the action-bar top artwork.
 - Fixed tooltip backgrounds used by SavedInstances and other LibQTip-based addons.
 
+## Bags
+
+- Added separate SharedMedia texture, thickness and color controls for bag frames and item borders, including the bag bar and utility buttons.
+- Separated background artwork, opacity, item backplates and borders. Background color no longer tints selected artwork, and item backplates stay beneath their icons.
+- Corrected visible border thickness for the bundled Stripped textures and supported Blizzard borders. Kept Details BarBorder 1 and 2 outlines stable as thickness changes, and adjusted Details BarBorder 3 sizing.
+- Applied item-quality colors to common and poor items and equipped bags. Empty item slots no longer show an item border, and native borders no longer overlap LUI borders.
+- Added Fill Bags from Bottom and kept its saved state in sync with Clean Bags. Reversed the displayed slots within each bag to remove gaps between partially filled and full bags, and deferred cleanup until the selected direction has updated.
+- Refreshed bag layout, fonts, search opacity and colors from the active profile. Kept toolbar styling current after native bag-slot updates and restored separators in the gold display.
+
+## Bank
+
+- Added optional LUI styling for Blizzard's current character and Warband banks. Use LUI Bank is disabled by default and restores Blizzard's appearance when turned off.
+- Reused bag textures, item borders and quality colors while retaining native bank tabs, item actions, search, deposits, withdrawals and confirmation dialogs.
+- Added bank row size, slot spacing, scale and optional extra spacing after every two columns.
+- Added an independent Fill Bank from Bottom display option so Clean Bank fills toward the bottom of the selected tab without changing the bag sorting preference.
+- Sized the bank window to contain the deposit controls and reagent checkbox text. Shortened the Warband title and tab label, removed the bright selected-tab glow and kept native tab sockets without an extra LUI outline.
+
 ## Other fixes
 
 - Fixed Experience Bars retaining an old profile after profile changes, preventing missing-width errors and keeping layout, text and drag settings tied to the active profile.

--- a/LUI.toc
+++ b/LUI.toc
@@ -69,6 +69,7 @@ modules\bags\toolbars.lua
 modules\bags\bags.lua
 modules\bags\templates.lua
 modules\bags\backpack.lua
+modules\bags\bank.lua
 
 ### Tooltip ###
 modules\tooltip\tooltip.lua

--- a/LUIOptions/Bags.lua
+++ b/LUIOptions/Bags.lua
@@ -112,6 +112,17 @@ end
 Bags.args = {
 	Header = Opt:Header({name = L["Bags_Name"]}),
 	Backpack = Opt:Group({name = L["Backpack Options"], get = GetBagValue, set = SetBagValue, args = GenerateBagsOptions()}),
+    Bank = Opt:Group({name = "Bank Options", get = GetSectionValue("Bank"), set = SetSectionValue("Bank"), args = {
+        Enabled = Opt:Toggle({name = "Use LUI Bank", desc = "Use LUI backgrounds, borders and a row-based item grid for the character and Warband bank. Blizzard's bank tabs, item actions, access restrictions and confirmation dialogs remain active.", width = "full"}),
+        Description = Opt:Desc({name = "The bank shares the Textures page and Show Item Quality setting with your bags. Open a banker to preview changes. Disable Use LUI Bank to restore Blizzard's appearance."}),
+        Layout = Opt:InlineGroup({name = "Bank Layout", disabled = function() return not module.db.profile.Bank.Enabled end, args = {
+            FillFromBottom = Opt:Toggle({name = "Fill Bank from Bottom", desc = "Display bank slots from bottom-right to top-left, so Clean Bank fills toward the bottom of each tab. Disable to fill from the top. Independent of the bag sorting option.", width = "full"}),
+            RowSize = Opt:Slider({name = "Items Per Row", desc = "Number of bank slots per row.", min = 8, max = 20, step = 1}),
+            Spacing = Opt:Slider({name = "Spacing", desc = "Distance between bank slots.", min = 0, max = 12, step = 1}),
+            ColumnGroupSpacing = Opt:Slider({name = "Column Group Spacing", desc = "Extra space after every two bank columns. Set to 0 for a uniform grid or 11 for Blizzard's additional gap between column pairs.", min = 0, max = 24, step = 1}),
+            Scale = Opt:Slider({name = "Scale", desc = "Overall size of the bank frame.", min = .5, max = 1.5, step = .1}),
+        }}),
+    }}),
 	Appearance = Opt:Group({name = L["Textures"], args = {
 		BackgroundTex = Opt:MediaBackground({
 			name = "Background Texture",

--- a/LUIOptions/Bags.lua
+++ b/LUIOptions/Bags.lua
@@ -6,60 +6,143 @@
 local Opt = select(2, ...)
 
 ---@type AceLocale.Localizations, LUI.Bags, AceDB-3.0
-local L, module, db = Opt:GetLUIModule("Bags")
+local L, module = Opt:GetLUIModule("Bags")
 if not module or not module.registered then return end
 
 local Bags = Opt:CreateModuleOptions("Bags", module)
+
+local function GetSectionValue(section)
+	return function(info)
+		local db = module.db.profile[section]
+		local value = db and db[info[#info]]
+		if info.type == "input" then
+			return value == nil and "" or tostring(value)
+		elseif info.type == "range" then
+			return tonumber(value)
+		end
+		return value
+	end
+end
+
+local function SetSectionValue(section)
+	return function(info, value)
+		local db = module.db.profile[section]
+		if not db then return end
+		if info.type == "input" or info.type == "range" then
+			value = tonumber(value)
+			if value == nil then return end
+		end
+		db[info[#info]] = value
+		if module.Refresh then module:Refresh() end
+	end
+end
+
+local GetBagValue = GetSectionValue("Bags")
+local SetBagValue = SetSectionValue("Bags")
+local GetTextureValue = GetSectionValue("Textures")
+
+local function IsItemBorderColorDisabled()
+	local db = module.db and module.db.profile and module.db.profile.Bags
+	return db and db.ItemQuality
+end
+
+local function SetTextureValue(info, value)
+	local db = module.db.profile.Textures
+	if not db then return end
+	if info.type == "range" then
+		value = tonumber(value)
+		if value == nil then return end
+		local key = info[#info]
+		if key == "ItemBorderSize" then
+			value = math.min(6, math.max(1, value))
+		elseif key == "BorderSize" then
+			value = math.min(32, math.max(1, value))
+		end
+	end
+	db[info[#info]] = value
+
+	-- SharedMedia is resolved and the LUI bag skin is reapplied in one refresh.
+	if module.Refresh then module:Refresh() end
+end
 
 -- ####################################################################################################################
 -- ##### Options Table ################################################################################################
 -- ####################################################################################################################
 
 local function GenerateBagsOptions()
-	local options = {
-		RowSize = Opt:Slider({name = "Items Per Row", desc = "Select how many items will be displayed per rows.", min = 1, max = 32, step = 1}),
+	return {
+		RowSize = Opt:Slider({name = "Items Per Row", desc = "Select how many items will be displayed per row.", min = 1, max = 32, step = 1}),
 		Spacer = Opt:Spacer({}),
-		Padding = Opt:Slider({name = "Padding", desc = "Distance between the frame's edge and the items.", min = 0, max = 32, step = 1 }),
+		Padding = Opt:Slider({name = "Padding", desc = "Distance between the frame edge and the items.", min = 0, max = 32, step = 1}),
 		Spacing = Opt:Slider({name = "Spacing", desc = "Distance between items.", min = 0, max = 32, step = 1}),
-		Scale = Opt:Slider({name = "Scale", desc = "Overall size of the container frame", min = 0.5, max = 2, step = 0.1}),
+		Scale = Opt:Slider({name = "Scale", desc = "Overall size of the container frame.", min = 0.5, max = 2, step = 0.1}),
 		Spacer2 = Opt:Spacer({}),
-			Lock = Opt:Toggle({name = "Lock Frame", desc = "Lock the frame in place"}),
-			BagBar = Opt:Toggle({name = "Show Bag Bar", desc = "Show the Bags bar"}),
-			BagNewline = Opt:Toggle({name = "Newline After Bags", desc = "Starts a new row for each bag."}),
-			Spacer3 = Opt:Spacer({}),
-			PositionHeader = Opt:Header({name = L["Position"]}),
-			X = Opt:PositionX(),
-			Y = Opt:PositionY(),
-			Spacer4 = Opt:Spacer({}),
-			ItemQuality = Opt:Toggle({name = "Show Item Quality", desc = "Colors item borders by their quality", width = "full"}),
-		ShowNew = Opt:Toggle({name = "Show New Item Animation", desc = "Highlights items marked as 'new'", width = "full"}),
-		ShowQuest = Opt:Toggle({name = "Show Quest Items", desc = "Highlights items that are part of a quest", width = "full"}),
-		ShowOverlay = Opt:Toggle({name = "Show Item Overlay", desc = "Display the overlay used for various types of items like Cosmetics and Crafting Quality.", width = "full"}),
-		ItemLevel = Opt:Toggle({name = "Show Item Level", desc = "Add Item Levels indicators for equipment", width = "full"}),
+		Lock = Opt:Toggle({name = "Lock Frame", desc = "Lock the frame in place."}),
+		BagBar = Opt:Toggle({name = "Show Bag Bar", desc = "Show the bag bar."}),
+		BagNewline = Opt:Toggle({name = "Newline After Bags", desc = "Start a new row for each bag."}),
+        ReverseCleanUp = Opt:Toggle({
+            name = "Fill Bags from Bottom",
+            desc = "Clean Bags fills toward the bottom of the LUI bag window. Slots within each bag are displayed in reverse order so partly filled bags meet the full bags below. Disable to fill from the top. Changing this option also cleans up your bags. Reagent bag restrictions and bag filters still apply.",
+            width = "full",
+            get = function() return module:GetFillBagsFromBottom() end,
+            set = function(_, value)
+                module:SetFillBagsFromBottom(value)
+            end,
+        }),
+		Spacer3 = Opt:Spacer({}),
+		PositionHeader = Opt:Header({name = L["Position"]}),
+		X = Opt:PositionX(),
+		Y = Opt:PositionY(),
+		Spacer4 = Opt:Spacer({}),
+		ItemQuality = Opt:Toggle({name = "Show Item Quality", desc = "Color items and equipped bags in the bag bar by quality, including gray for poor and white for common items. Empty item slots have no border. Item Border Color is disabled while this is enabled; empty bag sockets and utility buttons use Bag Border Color.", width = "full"}),
+		ShowNew = Opt:Toggle({name = "Show New Item Animation", desc = "Highlight items marked as new.", width = "full"}),
+		ShowQuest = Opt:Toggle({name = "Show Quest Items", desc = "Highlight items that are part of a quest.", width = "full"}),
+		ShowOverlay = Opt:Toggle({name = "Show Item Overlay", desc = "Display Blizzard item overlays such as cosmetics and crafting quality.", width = "full"}),
+		ItemLevel = Opt:Toggle({name = "Show Item Level", desc = "Show item levels on equippable items.", width = "full"}),
 	}
-	return options
 end
 
-local function ColorOptions(name, colorName)
+local function ColorOptions(name, colorName, disabled, desc)
 	local options = {}
-	options[colorName.."Type"] = Opt:ColorMenu(options, {name = name, arg = colorName})
+	options[colorName.."Type"] = Opt:ColorMenu(options, {name = name, arg = colorName, disabled = disabled, desc = desc})
 	return options
 end
 
 
 Bags.args = {
 	Header = Opt:Header({name = L["Bags_Name"]}),
-	Backpack = Opt:Group({name = L["Backpack Options"], db = db.Bags, args = GenerateBagsOptions()}),
+	Backpack = Opt:Group({name = L["Backpack Options"], get = GetBagValue, set = SetBagValue, args = GenerateBagsOptions()}),
 	Appearance = Opt:Group({name = L["Textures"], args = {
-		BackgroundTex = Opt:MediaBackground({name = L["Background"], db = db.Textures}),
-		BorderTex = Opt:MediaBorder({name = L["Border"], db = db.Textures}),
-		BorderSize = Opt:Slider({name = L["Thickness"], min = 1, max = 32, step = 1, db = db.Textures}),
+		BackgroundTex = Opt:MediaBackground({
+			name = "Background Texture",
+			desc = "Changes the background artwork used by the bag frame and toolbars.",
+			get = GetTextureValue, set = SetTextureValue,
+		}),
+		BorderTex = Opt:MediaBorder({
+			name = "Bag Border Texture",
+			desc = "Changes the SharedMedia border texture used by the outer bag frame and the toolbars above it.",
+			get = GetTextureValue, set = SetTextureValue,
+		}),
+		BorderSize = Opt:Slider({
+			name = "Bag Border Thickness", desc = "Changes the outer border thickness of the bag frame and toolbars without resizing their backgrounds. The bundled Stripped textures use the visible border width.",
+			min = 1, max = 32, step = 1, get = GetTextureValue, set = SetTextureValue,
+		}),
+		ItemBorderTex = Opt:MediaBorder({
+			name = "Item Border Texture",
+			desc = "Changes the SharedMedia border texture used by item and toolbar slots.",
+			get = GetTextureValue, set = SetTextureValue,
+		}),
+		ItemBorderSize = Opt:Slider({
+			name = "Item Border Thickness", desc = "Changes the border thickness used by item and toolbar slots.",
+			min = 1, max = 6, step = 1, get = GetTextureValue, set = SetTextureValue,
+		}),
 		BagFont = Opt:FontMenu({name = "Bag Text", customFontLocation = "Bags"}),
 		StackFont = Opt:FontMenu({name = "Item Count and Level", customFontLocation = "Stack"}),
 		Search = Opt:InlineGroup({name = "Search", args = ColorOptions("Search", "Search")}),
-		Background = Opt:InlineGroup({name = L["Background"], args = ColorOptions(L["Background"], "Background")}),
-		Border = Opt:InlineGroup({name = L["Border"], args = ColorOptions(L["Border"], "Border")}),
-		ItemBackground = Opt:InlineGroup({name = "Item Background", args = ColorOptions("Item Background", "ItemBackground")}),
+		Background = Opt:InlineGroup({name = L["Background"], args = ColorOptions(L["Background"], "Background", nil, "Used as the fill when no background texture is selected. With a texture selected, only this color setting's opacity is used and the artwork itself is not tinted.")}),
+		Border = Opt:InlineGroup({name = "Bag Border", args = ColorOptions("Bag Border", "Border")}),
+		ItemBorder = Opt:InlineGroup({name = "Item Border", args = ColorOptions("Item Border", "ItemBorder", IsItemBorderColorDisabled)}),
+		ItemBackground = Opt:InlineGroup({name = "Item Background", args = ColorOptions("Item Background", "ItemBackground", nil, "Colors the slot backplate underneath item icons, similar to a Masque button backdrop. This does not change the item border color.")}),
 		Professions = Opt:InlineGroup({name = "Profession Bag Slots", args = ColorOptions("Profession Bag Slots", "Professions")}),
 		BagText = Opt:InlineGroup({name = "Bag Text", args = ColorOptions("Bag Text", "Bags")}),
 		StackText = Opt:InlineGroup({name = "Item Count and Level", args = ColorOptions("Item Count and Level", "Stack")}),

--- a/LUIOptions/ExpBars.lua
+++ b/LUIOptions/ExpBars.lua
@@ -111,6 +111,11 @@ ExpBars.args = {
 		disabled = IsSpacingDisabled,
 	}),
 	ShowAzerite = Opt:Toggle({name = "Show Azerite XP when Heart of Azeroth is equipped.", width = "full"}),
+	AutoWatchReputation = Opt:Toggle({
+		name = "Automatically track reputation gains",
+		desc = "Switch the watched faction after a reputation gain. When several factions gain reputation together, follow the last reported faction. Applies to the reputation tracker in either bar position, including separate bars. Changes Blizzard's watched faction too. Reputation losses do not switch the tracker.",
+		width = "full",
+	}),
 
 	AppHeader = Opt:Header({name = "Appearances"}),
 	ExperienceType = Opt:ColorMenu(colorMenuOptions, {name = L["ExpBar_Mode_Experience"], arg = "Experience"}),

--- a/LUIOptions/Unitframes.lua
+++ b/LUIOptions/Unitframes.lua
@@ -377,6 +377,12 @@ local function GenerateTextGroup(unit, name, colorTypes, order)
         ShortValue = Opt:Toggle({name = "Short value", onlyIf = (dbText.ShortValue ~= nil)}),
     }})
 
+    if name == "RaidGroupText" then
+        group.args.Enable = Opt:Toggle({name = "Show Raid Group", desc = "Show your raid subgroup on the player frame. Hidden outside raids; the frame preview shows a sample group number.", width = "full"})
+        group.args.Color = nil
+        group.args.IndividualColor = Opt:Color({name = "Text Color", hasAlpha = false, db = dbText})
+    end
+
     if name == "AbsorbText" then
         group.args.Opacity = Opt:Slider({name = "Text Opacity", min = 0, max = 1, step = 0.01, isPercent = true, db = dbText})
         group.args.Prefix = Opt:Input({name = "Text Prefix", desc = "Text before the total shield amount. Leave empty to show only the number."})
@@ -701,6 +707,16 @@ local function NewUnitOptionGroup(unit, order, categorized)
     end
     
     if dbUnit.NameText then textOptions.args.NameText = GenerateTextGroup(unit, "NameText", nil, categorized and 1 or 30) end
+    if unit == "player" and dbUnit.RaidGroupText then textOptions.args.RaidGroupText = GenerateTextGroup(unit, "RaidGroupText", nil, categorized and 12 or 41) end
+    if unit == "raid" and dbUnit.GroupLabel then
+        local dbLabel = dbUnit.GroupLabel
+        textOptions.args.GroupLabel = Opt:Group({name = "Group Labels", order = categorized and 12 or 41, db = dbLabel, args = {
+            Enable = Opt:Toggle({name = "Show Group Labels", desc = "Label each occupied raid group outside its frames. Labels follow the group layout and are also shown in the raid preview.", width = "full"}),
+            Spacing = Opt:Slider({name = "Distance from Frames", min = 0, max = 50, step = 1}),
+            Color = Opt:Color({name = "Text Color", hasAlpha = false, db = dbLabel}),
+            Font = UnitFontMenu(dbLabel, "Text Font"),
+        }})
+    end
     if dbUnit.HealthText then textOptions.args.HealthText = GenerateTextGroup(unit, "HealthText", healthColorTypes, categorized and 2 or 31) end
     if dbUnit.PowerText then textOptions.args.PowerText = GenerateTextGroup(unit, "PowerText", powerColorTypes, categorized and 3 or 32) end
     if dbUnit.HealthPercentText then textOptions.args.HealthPercentText = GenerateTextGroup(unit, "HealthPercentText", healthColorTypes, categorized and 4 or 33) end

--- a/modules/bags/backpack.lua
+++ b/modules/bags/backpack.lua
@@ -7,7 +7,6 @@ local LUI = select(2, ...)
 
 ---@class LUI.Bags
 local module = LUI:GetModule("Bags")
-local Media = LibStub("LibSharedMedia-3.0")
 
 local GetNumWatchedTokens = _G.GetNumWatchedTokens
 local GetMoneyString = _G.GetMoneyString
@@ -95,18 +94,17 @@ function Bags:HideTitleBar()
 end
 
 function Bags:CreateTitleBar()
-	local db = module.db.profile.Fonts
 	local gold = self:CreateFontString(nil, "ARTWORK", "GameFontHighlightLarge")
 	gold:SetJustifyH("RIGHT")
 	gold:SetPoint("RIGHT", self.closeButton, "LEFT", -3, 0)
-	gold:SetFont(Media:Fetch("font", db.Bags.Name), db.Bags.Size, db.Bags.Flag)
+	module:RefreshBagFontString(gold, "Bags")
 
 	-- Watched Currency Display, next to gold
 	local currency = self:CreateFontString(nil, "ARTWORK", "GameFontHighlightLarge")
 	currency:SetJustifyH("RIGHT")
 	currency:SetPoint("RIGHT", gold, "LEFT", -25, 0)
 	currency:SetText(self:GetCurrencyString())
-	currency:SetFont(Media:Fetch("font", db.Bags.Name), db.Bags.Size, db.Bags.Flag)
+	module:RefreshBagFontString(currency, "Bags")
 
 	local updateFunc = function() self:UpdateCurrencies() end
 	self:SetScript("OnEvent", updateFunc)
@@ -135,11 +133,7 @@ function Bags:GetCurrencyString()
 end
 
 function Bags:UpdateCurrencies()
-	if not module.originalBackpackTokenWidth then
-		module.originalBackpackTokenWidth = BackpackTokenFrame:GetWidth()
-	end
-	BackpackTokenFrame:SetWidth(self:GetWidth())
-	self.gold:SetText(GetMoneyString(GetMoney()))
+	self.gold:SetText(GetMoneyString(GetMoney(), true))
 	self.currency:SetText(self:GetCurrencyString())
 end
 
@@ -164,7 +158,7 @@ function Bags:CreateUtilBar()
 	local utilBar = self.utilBar
 
 	--CleanUp
-	local button = module:CreateCleanUpButton("LUIBags_CleanUp", utilBar, C_Container.SortBags)
+	local button = module:CreateCleanUpButton("LUIBags_CleanUp", utilBar, function() module:SortBags() end)
 	utilBar:AddNewButton(button)
 end
 

--- a/modules/bags/bags.lua
+++ b/modules/bags/bags.lua
@@ -836,7 +836,13 @@ function ContainerMixin:BagUpdateEvent(idList)
 
 	-- Sorting moves items over multiple updates. Reapply the selected layout
 	-- after those updates instead of relying only on the initial option click.
-	if self.name == "Bags" then self:SetAnchors() end
+	if self.name == "Bags" then
+		if module.bagSortSettling then
+			self.bottomLootOrder = nil
+			module:ScheduleBagLootLayout()
+		end
+		self:SetAnchors()
+	end
 
 	-- Update Search Results if searching
 	if self.editbox:IsShown() then
@@ -863,6 +869,39 @@ function module:SetFillBagsFromBottom(value)
     module:SortBags()
 end
 
+function module:ResetBagLootOrder()
+    for _, container in pairs(containerStorage) do
+        container.bottomLootOrder = nil
+    end
+end
+
+function module:ScheduleBagLootLayout()
+    if module.bagLootLayoutTimer then module.bagLootLayoutTimer:Cancel() end
+    -- Native cleanup moves items over several BAG_UPDATE batches. Establish
+    -- the next loot layout only once those batches have settled.
+    module.bagLootLayoutTimer = C_Timer.NewTimer(.25, function()
+        module.bagLootLayoutTimer = nil
+        module.bagSortSettling = nil
+        module:ResetBagLootOrder()
+        for _, container in pairs(containerStorage) do
+            container:SetAnchors()
+        end
+    end)
+end
+
+function module:ConfigureBagLootInsertion()
+    if module.originalBagInsertOrder == nil then
+        module.originalBagInsertOrder = C_Container.GetInsertItemsLeftToRight()
+    end
+    -- Start looting at the opposite end from cleanup: backpack first when
+    -- sorting down, last normal bag first when sorting up. Blizzard retains
+    -- ownership of bag filters, reagent restrictions and existing stacks.
+    local insertFromLastBag = not module:GetFillBagsFromBottom()
+    if C_Container.GetInsertItemsLeftToRight() ~= insertFromLastBag then
+        C_Container.SetInsertItemsLeftToRight(insertFromLastBag)
+    end
+end
+
 function module:SortBags()
     C_Container.SetSortBagsRightToLeft(not module:GetFillBagsFromBottom())
     if module.bagSortTimer then module.bagSortTimer:Cancel() end
@@ -870,9 +909,52 @@ function module:SortBags()
     -- Coalesce quick clicks so an old request cannot sort the new selection.
     module.bagSortTimer = C_Timer.NewTimer(0, function()
         module.bagSortTimer = nil
+        module.bagSortSettling = true
+        module:ResetBagLootOrder()
         C_Container.SortBags()
         module:Refresh()
+        module:ScheduleBagLootLayout()
     end)
+end
+
+local function GetBagLootSlots(container, id, reverseSlots)
+    local source = container.itemList[id]
+    local count = 0
+    for _, slot in ipairs(source) do
+        if slot:IsShown() then count = count + 1 end
+    end
+    local cache = container.bottomLootOrder
+    if not cache or cache.profile ~= module.db.profile or cache.reverseSlots ~= reverseSlots then
+        cache = { profile = module.db.profile, reverseSlots = reverseSlots }
+        container.bottomLootOrder = cache
+    end
+    local order = cache[id]
+    if not order or order.source ~= source or #order ~= count then
+        order = { source = source }
+        for i = 1, #source do
+            local index = reverseSlots and (#source - i + 1) or i
+            if source[index]:IsShown() then order[#order + 1] = source[index] end
+        end
+    end
+    local free, empty = {}, {}
+    for _, slot in ipairs(source) do
+        if slot:IsShown() and not C_Container.GetContainerItemInfo(id, slot.slot) then
+            free[#free + 1] = slot
+            empty[slot] = true
+        end
+    end
+    local nextFree = 1
+    for i, slot in ipairs(order) do
+        -- Only remap empty positions. Occupied slots retain their positions as
+        -- loot arrives. Empty positions follow native insertion order from
+        -- the top when sorting down, or from the bottom when sorting up.
+        if empty[slot] then
+            order[i] = free[reverseSlots and nextFree or (#free - nextFree + 1)]
+            nextFree = nextFree + 1
+        end
+    end
+    cache[id] = order
+    return order
 end
 
 -- This function will set all itemslot anchors and the container's dimensions based on that.
@@ -895,12 +977,12 @@ function ContainerMixin:SetAnchors()
 	local reverseSlots = self.name == "Bags" and module:GetFillBagsFromBottom()
 	for i = 1, self.NUM_BAG_IDS do
 		local id = self.BAG_ID_LIST[i]
+		local displaySlots = self.name == "Bags" and GetBagLootSlots(self, id, reverseSlots) or self.itemList[id]
 		if self:GetOption("BagNewline") then
 			index = 0
 		end
-		for j = 1, #self.itemList[id] do
-			local slotIndex = reverseSlots and (#self.itemList[id] - j + 1) or j
-			local itemSlot = self.itemList[id][slotIndex]
+		for j = 1, #displaySlots do
+			local itemSlot = displaySlots[j]
 			-- Make sure to clear points to prevent errors.
 			itemSlot:ClearAllPoints()
 			-- ItemSlots beyond bagCount are hidden, so we don't count them
@@ -1154,6 +1236,7 @@ end
 -- ####################################################################################################################
 function module:Refresh()
     if not module.db or not module.db.profile then return end
+    module:ConfigureBagLootInsertion()
     module:RefreshMedia()
 
     for _, container in pairs(containerStorage) do
@@ -1263,5 +1346,13 @@ function module:SetBags()
 end
 
 function module:RestoreBlizzardBagState()
+	if module.bagSortTimer then module.bagSortTimer:Cancel(); module.bagSortTimer = nil end
+	if module.bagLootLayoutTimer then module.bagLootLayoutTimer:Cancel(); module.bagLootLayoutTimer = nil end
+	module.bagSortSettling = nil
+	module:ResetBagLootOrder()
+	if module.originalBagInsertOrder ~= nil then
+		C_Container.SetInsertItemsLeftToRight(module.originalBagInsertOrder)
+		module.originalBagInsertOrder = nil
+	end
 	if _G.LUIBags then _G.LUIBags:UnregisterAllEvents() end
 end

--- a/modules/bags/bags.lua
+++ b/modules/bags/bags.lua
@@ -25,8 +25,9 @@ local SetItemButtonDesaturated = _G.SetItemButtonDesaturated
 local ClearItemButtonOverlay = _G.ClearItemButtonOverlay
 local SetItemButtonOverlay = _G.SetItemButtonOverlay
 local SetItemButtonTexture = _G.SetItemButtonTexture
-local GetItemQualityColor = C_Item.GetItemQualityColor
 local SetItemButtonCount = _G.SetItemButtonCount
+local GetItemQualityColor = C_Item.GetItemQualityColor
+local GetInventoryItemQuality = _G.GetInventoryItemQuality
 local GetDetailedItemLevelInfo = C_Item.GetDetailedItemLevelInfo
 
 local TEXTURE_ITEM_QUEST_BORDER = _G.TEXTURE_ITEM_QUEST_BORDER
@@ -42,10 +43,430 @@ local LAYOUT_OFFSET = 26
 
 local ITEMSLOT_NORMAL_ALPHA = 1
 local ITEMSLOT_FILTER_ALPHA = .2
-local BACKGROUND_MULTIPLIER = 0.4
 
 -- Local variables
 local containerStorage = {}
+
+-- LUI bag visuals use ordinary texture regions. SharedMedia border files are
+-- drawn by eight lightweight edge pieces using the packed coordinates those
+-- media files were authored for, keeping background and border rendering fully
+-- independent.
+local max = math.max
+local min = math.min
+local BORDER_PIECES = {
+    "TopLeftCorner", "TopRightCorner", "BottomLeftCorner", "BottomRightCorner",
+    "TopEdge", "BottomEdge", "LeftEdge", "RightEdge",
+}
+local COORD_START = 0.0625
+local COORD_END = 1 - COORD_START
+local CORNER_UVS = {
+    TopLeftCorner     = {0.5078125, COORD_START, 0.5078125, COORD_END, 0.6171875, COORD_START, 0.6171875, COORD_END},
+    TopRightCorner    = {0.6328125, COORD_START, 0.6328125, COORD_END, 0.7421875, COORD_START, 0.7421875, COORD_END},
+    BottomLeftCorner  = {0.7578125, COORD_START, 0.7578125, COORD_END, 0.8671875, COORD_START, 0.8671875, COORD_END},
+    BottomRightCorner = {0.8828125, COORD_START, 0.8828125, COORD_END, 0.9921875, COORD_START, 0.9921875, COORD_END},
+}
+
+-- These bundled 128x16 borders have only 3 or 5 painted pixels across each
+-- 16px tile. Crop their transparent margins for the outer bag frame so its
+-- thickness setting sizes the painted band, not the mostly empty tile.
+local STRIPPED_BANDS = {
+    ["interface/addons/lui/media/borders/stripped.tga"] = {1, 6},
+    ["interface/addons/lui/media/borders/stripped_medium.tga"] = {2, 5},
+    ["interface/addons/lui/media/borders/stripped_hard.tga"] = {1, 6},
+}
+
+-- Measured from the Blizzard/Details packed border images: tile size, painted
+-- band start/end, and corner extent (exclusive pixel coordinates). Rounded
+-- and ornamental corners need more room than the straight painted band.
+local MEASURED_BORDERS = {
+    ["interface/dialogframe/ui-dialogbox-border"] = {32, 0, 16, 18},
+    ["interface/dialogframe/ui-dialogbox-gold-border"] = {32, 0, 16, 18},
+    ["interface/tooltips/ui-tooltip-border"] = {16, 1, 6, 9},
+    ["interface/addons/details/images/border_3"] = {16, 2, 5, 5},
+}
+
+-- Details 1/2 are one-pixel outlines: bevelled and square respectively.
+-- Reproduce those contours with solid quads instead of magnifying their tiny
+-- corner bitmaps. The outer corner cut stays fixed as the stroke grows inward.
+local THIN_OUTLINES = {
+    ["interface/addons/details/images/border_1"] = 3,
+    ["interface/addons/details/images/border_2"] = 0,
+}
+local OUTLINE_SEGMENTS = {
+    "TopEdge", "TopRightCorner", "RightEdge", "BottomRightCorner",
+    "BottomEdge", "BottomLeftCorner", "LeftEdge", "TopLeftCorner",
+}
+
+local function UpdateThinOutline(target, skin)
+    local width, height = target:GetWidth(), target:GetHeight()
+    if issecretvalue(width) or issecretvalue(height) or width <= 0 or height <= 0 then return end
+    local thickness = min(skin.borderSize, width / 2, height / 2)
+    local cut = min(skin.outlineCut, width / 4, height / 4)
+    local innerCut = max(0, cut - (2 - math.sqrt(2)) * thickness)
+    innerCut = min(innerCut, (width - 2 * thickness) / 2, (height - 2 * thickness) / 2)
+    local function Contour(inset, corner)
+        local left, top, right, bottom = inset, inset, width - inset, height - inset
+        return {
+            {left + corner, top}, {right - corner, top},
+            {right, top + corner}, {right, bottom - corner},
+            {right - corner, bottom}, {left + corner, bottom},
+            {left, bottom - corner}, {left, top + corner},
+        }
+    end
+    local outer, inner = Contour(0, cut), Contour(thickness, innerCut)
+    for i, name in ipairs(OUTLINE_SEGMENTS) do
+        local nextIndex = i % 8 + 1
+        local a, b, c, d = outer[i], outer[nextIndex], inner[nextIndex], inner[i]
+        local piece = skin.borderPieces[name]
+        piece:ClearAllPoints()
+        piece:SetAllPoints(target)
+        piece:SetColorTexture(1, 1, 1, 1)
+        piece:SetTexCoord(0, 1, 0, 1)
+        -- Vertex indices: upper left, lower left, upper right, lower right.
+        piece:SetVertexOffset(1, a[1], -a[2])
+        piece:SetVertexOffset(3, b[1] - width, -b[2])
+        piece:SetVertexOffset(4, c[1] - width, height - c[2])
+        piece:SetVertexOffset(2, d[1], height - d[2])
+        local color = skin.borderColor
+        if color then piece:SetVertexColor(color[1], color[2], color[3], color[4]) end
+    end
+end
+
+local function UpdateMeasuredBorder(target, skin, profile)
+    local tileSize, first, last, cornerEnd = profile[1], profile[2], profile[3], profile[4]
+    local bandWidth = last - first
+    local edgeSize = skin.borderSize
+    local cornerSize = edgeSize * (cornerEnd - first) / bandWidth
+    local width, height = target:GetWidth(), target:GetHeight()
+    local readable = not issecretvalue(width) and not issecretvalue(height)
+    if readable and width > 0 and height > 0 then
+        local limit = min(width, height) / 2
+        edgeSize = min(edgeSize, limit)
+        cornerSize = min(edgeSize * (cornerEnd - first) / bandWidth, limit)
+        -- Crop the straight tails of large corners on small item buttons;
+        -- reducing the entire skin here would also reduce the chosen thickness.
+        cornerEnd = first + cornerSize * bandWidth / edgeSize
+    end
+    local pieces = skin.borderPieces
+    local function Corner(name, tile, right, bottom)
+        local x1, x2 = first, cornerEnd
+        local y1, y2 = first, cornerEnd
+        if right then x1, x2 = tileSize - cornerEnd, tileSize - first end
+        if bottom then y1, y2 = tileSize - cornerEnd, tileSize - first end
+        pieces[name]:SetSize(cornerSize, cornerSize)
+        pieces[name]:SetTexCoord((tile * tileSize + x1) / (8 * tileSize), (tile * tileSize + x2) / (8 * tileSize), y1 / tileSize, y2 / tileSize)
+    end
+    Corner("TopLeftCorner", 4, false, false)
+    Corner("TopRightCorner", 5, true, false)
+    Corner("BottomLeftCorner", 6, false, true)
+    Corner("BottomRightCorner", 7, true, true)
+    pieces.TopEdge:SetHeight(edgeSize)
+    pieces.BottomEdge:SetHeight(edgeSize)
+    pieces.LeftEdge:SetWidth(edgeSize)
+    pieces.RightEdge:SetWidth(edgeSize)
+
+    local repeatX, repeatY = 1, 1
+    if readable then
+        local tileLength = edgeSize * tileSize / bandWidth
+        repeatX = max(1, (width - 2 * cornerSize) / tileLength)
+        repeatY = max(1, (height - 2 * cornerSize) / tileLength)
+    end
+    local textureWidth = 8 * tileSize
+    local left1, left2 = first / textureWidth, last / textureWidth
+    local right1, right2 = (2 * tileSize - last) / textureWidth, (2 * tileSize - first) / textureWidth
+    local top1, top2 = (2 * tileSize + first) / textureWidth, (2 * tileSize + last) / textureWidth
+    local bottom1, bottom2 = (4 * tileSize - last) / textureWidth, (4 * tileSize - first) / textureWidth
+    pieces.LeftEdge:SetTexCoord(left1, left2, 0, repeatY)
+    pieces.RightEdge:SetTexCoord(right1, right2, 0, repeatY)
+    pieces.TopEdge:SetTexCoord(top1, repeatX, top2, repeatX, top1, 0, top2, 0)
+    pieces.BottomEdge:SetTexCoord(bottom1, repeatX, bottom2, repeatX, bottom1, 0, bottom2, 0)
+end
+
+local function SetStrippedBorderCoordinates(pieces, band)
+    local first, last = band[1] + 0.5, band[2] - 0.5
+    local oppositeFirst, oppositeLast = 16 - last, 16 - first
+    local function Corner(name, tile, left, right, top, bottom)
+        pieces[name]:SetTexCoord((tile * 16 + left) / 128, (tile * 16 + right) / 128, top / 16, bottom / 16)
+    end
+    Corner("TopLeftCorner", 4, first, last, first, last)
+    Corner("TopRightCorner", 5, oppositeFirst, oppositeLast, first, last)
+    Corner("BottomLeftCorner", 6, first, last, oppositeFirst, oppositeLast)
+    Corner("BottomRightCorner", 7, oppositeFirst, oppositeLast, oppositeFirst, oppositeLast)
+    pieces.LeftEdge:SetTexCoord(first / 128, last / 128, COORD_START, COORD_END)
+    pieces.RightEdge:SetTexCoord((16 + oppositeFirst) / 128, (16 + oppositeLast) / 128, COORD_START, COORD_END)
+    pieces.TopEdge:SetTexCoord((32 + first) / 128, COORD_END, (32 + last) / 128, COORD_END,
+        (32 + first) / 128, COORD_START, (32 + last) / 128, COORD_START)
+    pieces.BottomEdge:SetTexCoord((48 + oppositeFirst) / 128, COORD_END, (48 + oppositeLast) / 128, COORD_END,
+        (48 + oppositeFirst) / 128, COORD_START, (48 + oppositeLast) / 128, COORD_START)
+end
+
+local function SetComplexTexCoord(texture, coords)
+    texture:SetTexCoord(coords[1], coords[2], coords[3], coords[4], coords[5], coords[6], coords[7], coords[8])
+end
+
+local function FetchBagMedia(mediaType, key, fallback)
+    if key == "None" then return nil end
+    local texture
+    if type(key) == "string" and key ~= "" then
+        texture = Media:Fetch(mediaType, key, true)
+    end
+    if (not texture or texture == "") and fallback then
+        texture = Media:Fetch(mediaType, fallback, true)
+    end
+    return texture ~= "" and texture or nil
+end
+
+local function EnsureBagSkin(target)
+    local skin = target.LUIBagSkin
+    if skin then return skin end
+
+    skin = { borderPieces = {} }
+    target.LUIBagSkin = skin
+
+    skin.artwork = target:CreateTexture(nil, "BACKGROUND", nil, -8)
+    skin.artwork:SetAllPoints(target)
+
+    skin.tint = target:CreateTexture(nil, "BACKGROUND", nil, -7)
+    skin.tint:SetAllPoints(target)
+
+    for _, name in ipairs(BORDER_PIECES) do
+        skin.borderPieces[name] = target:CreateTexture(nil, "OVERLAY", nil, 6)
+    end
+
+    target:HookScript("OnSizeChanged", function(self)
+        module:UpdateSkinBorderCoordinates(self)
+    end)
+    return skin
+end
+
+function module:UpdateSkinBorderCoordinates(target)
+    local skin = target and target.LUIBagSkin
+    if not skin or not skin.borderTexture then return end
+    if skin.outlineCut ~= nil then
+        UpdateThinOutline(target, skin)
+        return
+    end
+    if skin.measuredBorder then
+        UpdateMeasuredBorder(target, skin, skin.measuredBorder)
+        return
+    end
+
+    local edgeSize = skin.borderSize or 1
+    local width, height = target:GetWidth(), target:GetHeight()
+    local readable = not issecretvalue(width) and not issecretvalue(height)
+    if skin.fitBorder and readable and width > 0 and height > 0 then
+        -- A small toolbar must not end up with overlapping corners.
+        edgeSize = min(edgeSize, width / 2, height / 2)
+        for _, name in ipairs({"TopLeftCorner", "TopRightCorner", "BottomLeftCorner", "BottomRightCorner"}) do
+            skin.borderPieces[name]:SetSize(edgeSize, edgeSize)
+        end
+        skin.borderPieces.TopEdge:SetHeight(edgeSize)
+        skin.borderPieces.BottomEdge:SetHeight(edgeSize)
+        skin.borderPieces.LeftEdge:SetWidth(edgeSize)
+        skin.borderPieces.RightEdge:SetWidth(edgeSize)
+    end
+    if skin.strippedBand then
+        SetStrippedBorderCoordinates(skin.borderPieces, skin.strippedBand)
+        return
+    end
+    local repeatX, repeatY = COORD_END, COORD_END
+    if readable then
+        -- Both frame dimensions and edgeSize are already in the same UI units.
+        local corners = skin.fitBorder and 2 or 1
+        repeatX = max(COORD_END, width / edgeSize - corners - COORD_START)
+        repeatY = max(COORD_END, height / edgeSize - corners - COORD_START)
+    end
+
+    local pieces = skin.borderPieces
+    pieces.TopEdge:SetTexCoord(0.2578125, repeatX, 0.3671875, repeatX, 0.2578125, COORD_START, 0.3671875, COORD_START)
+    pieces.BottomEdge:SetTexCoord(0.3828125, repeatX, 0.4921875, repeatX, 0.3828125, COORD_START, 0.4921875, COORD_START)
+    pieces.LeftEdge:SetTexCoord(0.0078125, COORD_START, 0.0078125, repeatY, 0.1171875, COORD_START, 0.1171875, repeatY)
+    pieces.RightEdge:SetTexCoord(0.1328125, COORD_START, 0.1328125, repeatY, 0.2421875, COORD_START, 0.2421875, repeatY)
+end
+
+function module:RefreshMedia()
+    local profile = module.db and module.db.profile
+    local db = profile and profile.Textures
+    if not db then return end
+
+    module.bagMedia = module.bagMedia or {}
+    module.bagMedia.background = FetchBagMedia("background", db.BackgroundTex, "Blizzard Tooltip")
+    module.bagMedia.border = FetchBagMedia("border", db.BorderTex, "Stripped_medium")
+    module.bagMedia.itemBorder = FetchBagMedia("border", db.ItemBorderTex, "Stripped_medium")
+    module.bagMedia.borderSize = math.max(1, tonumber(db.BorderSize) or 5)
+    -- Item buttons are only 36 px. Keep the usable range small enough that the
+    -- border remains a border instead of swallowing the icon.
+    module.bagMedia.itemBorderSize = min(6, math.max(1, tonumber(db.ItemBorderSize) or 3))
+end
+
+function module:ApplyBackgroundStyle(target, colorKey)
+    if not target then return end
+    local skin = EnsureBagSkin(target)
+    local texture = module.bagMedia and module.bagMedia.background
+    local r, g, b, a = module:RGBA(colorKey)
+    r, g, b = tonumber(r) or 1, tonumber(g) or 1, tonumber(b) or 1
+    a = tonumber(a) or 1
+
+    skin.tint:SetDrawLayer("BACKGROUND", -8)
+    skin.artwork:SetDrawLayer("BACKGROUND", -7)
+
+    if texture then
+        -- A selected background texture is artwork, not a color swatch. Never
+        -- multiply it by Background Color; only the saved opacity affects it.
+        skin.tint:Hide()
+        skin.artwork:SetTexture(texture)
+        skin.artwork:SetVertexColor(1, 1, 1, 1)
+        skin.artwork:SetAlpha(a)
+        skin.artwork:Show()
+    else
+        -- With no artwork selected, Background Color becomes the actual fill.
+        skin.artwork:Hide()
+        skin.tint:SetColorTexture(r, g, b, a)
+        skin.tint:Show()
+    end
+end
+
+function module:ApplyItemBackgroundStyle(target)
+    if not target then return end
+    local skin = EnsureBagSkin(target)
+    local r, g, b, a = module:RGBA("ItemBackground")
+    local name = target:GetName()
+    local icon = target.icon or target.Icon or (name and _G[name.."IconTexture"])
+    local inset = 3
+
+    -- This is the slot backplate underneath the item icon, similar to a Masque
+    -- button backdrop. It is deliberately separate from the item border.
+    skin.artwork:Hide()
+    skin.tint:SetDrawLayer("BORDER", -8)
+    skin.tint:ClearAllPoints()
+    -- Keep the backplate beneath the icon, including its transparent parts.
+    -- A larger rectangle reads as a second border around narrow/rounded skins.
+    if icon then
+        skin.tint:SetAllPoints(icon)
+    else
+        skin.tint:SetPoint("TOPLEFT", target, "TOPLEFT", inset, -inset)
+        skin.tint:SetPoint("BOTTOMRIGHT", target, "BOTTOMRIGHT", -inset, inset)
+    end
+    skin.tint:SetColorTexture(tonumber(r) or 0.18, tonumber(g) or 0.18, tonumber(b) or 0.18, tonumber(a) or 0.8)
+    skin.tint:Show()
+end
+
+function module:HideSkinBorder(target)
+    local skin = target and target.LUIBagSkin
+    if not skin then return end
+    skin.borderTexture = nil
+    for _, piece in pairs(skin.borderPieces) do piece:Hide() end
+end
+
+function module:SetSkinBorderShown(target, shown)
+    local skin = target and target.LUIBagSkin
+    if not skin then return end
+    for _, piece in pairs(skin.borderPieces) do
+        piece:SetShown(shown and skin.borderTexture ~= nil)
+    end
+end
+
+function module:SetSkinBorderColor(target, r, g, b, a)
+    local skin = target and target.LUIBagSkin
+    if not skin then return end
+    r, g, b, a = tonumber(r) or 1, tonumber(g) or 1, tonumber(b) or 1, tonumber(a) or 1
+    skin.borderColor = {r, g, b, a}
+    for _, piece in pairs(skin.borderPieces) do piece:SetVertexColor(r, g, b, a) end
+end
+
+function module:ApplyBorderStyle(target, edgeTexture, edgeSize, colorKey, fitBorder)
+    if not target then return end
+    local skin = EnsureBagSkin(target)
+    if not edgeTexture then
+        module:HideSkinBorder(target)
+        return
+    end
+
+    edgeSize = math.max(1, tonumber(edgeSize) or 1)
+    skin.borderTexture = edgeTexture
+    skin.borderSize = edgeSize
+    skin.fitBorder = fitBorder
+    local texturePath = type(edgeTexture) == "string" and edgeTexture:lower():gsub("\\", "/"):gsub("/+", "/")
+    skin.strippedBand = fitBorder and STRIPPED_BANDS[texturePath] or nil
+    local measuredPath = texturePath and texturePath:gsub("%.tga$", ""):gsub("%.blp$", "")
+    skin.measuredBorder = fitBorder and MEASURED_BORDERS[measuredPath] or nil
+    skin.outlineCut = fitBorder and THIN_OUTLINES[measuredPath] or nil
+    local pieces = skin.borderPieces
+
+    local topLeft, topRight = pieces.TopLeftCorner, pieces.TopRightCorner
+    local bottomLeft, bottomRight = pieces.BottomLeftCorner, pieces.BottomRightCorner
+    local top, bottom, left, right = pieces.TopEdge, pieces.BottomEdge, pieces.LeftEdge, pieces.RightEdge
+
+    for _, piece in pairs(pieces) do
+        piece:ClearAllPoints()
+        -- A different selected texture must not inherit the outline geometry.
+        piece:ClearVertexOffsets()
+        piece:SetTexture(edgeTexture, true, true)
+        piece:Show()
+    end
+
+    -- Keep the outside fixed while the border grows inward. The icon/backplate
+    -- remains independently anchored and colored.
+    topLeft:SetPoint(fitBorder and "TOPLEFT" or "CENTER", target, "TOPLEFT")
+    topRight:SetPoint(fitBorder and "TOPRIGHT" or "CENTER", target, "TOPRIGHT")
+    bottomLeft:SetPoint(fitBorder and "BOTTOMLEFT" or "CENTER", target, "BOTTOMLEFT")
+    bottomRight:SetPoint(fitBorder and "BOTTOMRIGHT" or "CENTER", target, "BOTTOMRIGHT")
+    topLeft:SetSize(edgeSize, edgeSize)
+    topRight:SetSize(edgeSize, edgeSize)
+    bottomLeft:SetSize(edgeSize, edgeSize)
+    bottomRight:SetSize(edgeSize, edgeSize)
+
+    top:SetPoint("TOPLEFT", topLeft, "TOPRIGHT")
+    top:SetPoint("TOPRIGHT", topRight, "TOPLEFT")
+    top:SetHeight(edgeSize)
+    bottom:SetPoint("BOTTOMLEFT", bottomLeft, "BOTTOMRIGHT")
+    bottom:SetPoint("BOTTOMRIGHT", bottomRight, "BOTTOMLEFT")
+    bottom:SetHeight(edgeSize)
+    left:SetPoint("TOPLEFT", topLeft, "BOTTOMLEFT")
+    left:SetPoint("BOTTOMLEFT", bottomLeft, "TOPLEFT")
+    left:SetWidth(edgeSize)
+    right:SetPoint("TOPRIGHT", topRight, "BOTTOMRIGHT")
+    right:SetPoint("BOTTOMRIGHT", bottomRight, "TOPRIGHT")
+    right:SetWidth(edgeSize)
+
+    for name, coords in pairs(CORNER_UVS) do
+        SetComplexTexCoord(pieces[name], coords)
+    end
+    module:UpdateSkinBorderCoordinates(target)
+    module:SetSkinBorderColor(target, module:RGBA(colorKey))
+end
+
+function module:ApplyBagFrameStyle(target)
+    module:ApplyBackgroundStyle(target, "Background")
+    local media = module.bagMedia or {}
+    module:ApplyBorderStyle(target, media.border, media.borderSize, "Border", true)
+end
+
+function module:ApplyItemStyle(target)
+    module:ApplyItemBackgroundStyle(target)
+    local media = module.bagMedia or {}
+    module:ApplyBorderStyle(target, media.itemBorder, media.itemBorderSize, "ItemBorder", true)
+    module:SetSkinBorderShown(target, target.LUIHasItem ~= false)
+end
+
+function module:SetToolbarSlotBorderColor(slot, container)
+    local colorKey = "Border"
+    if slot.isBag and slot.inventoryID then
+        if container:GetOption("ItemQuality") then
+            local quality = GetInventoryItemQuality("player", slot.inventoryID)
+            if quality ~= nil then
+                local r, g, b = GetItemQualityColor(quality)
+                module:SetSkinBorderColor(slot, r, g, b, 1)
+                return
+            end
+        else
+            colorKey = "ItemBorder"
+        end
+    end
+    -- Empty bag sockets and utility buttons have no item quality. Use a color
+    -- that remains editable while Show Item Quality disables Item Border Color.
+    module:SetSkinBorderColor(slot, module:RGBA(colorKey))
+end
 
 -- ####################################################################################################################
 -- ##### Container Mixin ##############################################################################################
@@ -53,6 +474,25 @@ local containerStorage = {}
 
 ---@class ContainerMixin : Frame
 local ContainerMixin = {}
+
+function ContainerMixin:GetDB()
+	local profile = module.db and module.db.profile
+	return profile and profile[self.profileKey or self.name]
+end
+
+function module:ApplyBagTextColor(fontString, colorKey)
+	if not fontString then return end
+	local r, g, b, a = module:RGBA(colorKey)
+	if r and g and b then
+		fontString:SetTextColor(r, g, b, a or 1)
+	end
+end
+
+function module:RefreshBagFontString(fontString, fontKey, colorKey)
+	if not fontString then return end
+	module:RefreshFontString(fontString, fontKey)
+	module:ApplyBagTextColor(fontString, colorKey or fontKey)
+end
 
 function ContainerMixin:Open()
 	self:Show()
@@ -71,7 +511,8 @@ function ContainerMixin:Toggle()
 end
 
 function ContainerMixin:StartMovingFrame()
-	if not self.db.Lock then
+	local db = self:GetDB()
+	if db and not db.Lock then
 		self:StartMoving()
 	end
 end
@@ -79,8 +520,10 @@ end
 function ContainerMixin:StopMovingFrame()
 	self:StopMovingOrSizing()
 	local x, y = self:GetCenter()
-	self.db.X = x
-	self.db.Y = y
+	local db = self:GetDB()
+	if not db then return end
+	db.X = x
+	db.Y = y
 end
 
 function ContainerMixin:QueueBagUpdate(id)
@@ -161,7 +604,8 @@ function ContainerMixin:HideTitleBar()
 end
 
 function ContainerMixin:GetOption(name)
-	return self.db[name]
+	local db = self:GetDB()
+	return db and db[name]
 end
 
 function ContainerMixin:IsValidID(id)
@@ -206,10 +650,13 @@ end
 
 function ContainerMixin:SetPosition()
 	self:ClearAllPoints()
-	if not self.db.X or self.db.X == 0 and self.db.Y == 0 then
+	local db = self:GetDB()
+	local x = db and tonumber(db.X) or 0
+	local y = db and tonumber(db.Y) or 0
+	if x == 0 and y == 0 then
 		self:SetPoint("CENTER", UIParent, "CENTER")
 	else
-		self:SetPoint("CENTER", UIParent, "BOTTOMLEFT", self.db.X, self.db.Y)
+		self:SetPoint("CENTER", UIParent, "BOTTOMLEFT", x, y)
 	end
 end
 
@@ -235,14 +682,8 @@ end
 -- Container-specific code creates Blizzard item-slot templates; this method
 -- applies the shared LUI presentation afterward.
 function ContainerMixin:SetItemSlotProperties(itemSlot)
-	--Make it easy to fetch Cooldown information
-	itemSlot.cooldown = _G[itemSlot:GetName() .. "Cooldown"]
-
-	--Update backdrop
-	LUI:ApplyFrameBackdrop(itemSlot, module.itemBackdrop)
-	LUI:SetFrameBackgroundColor(itemSlot, module:RGBA("ItemBackground"))
+    itemSlot.cooldown = _G[itemSlot:GetName() .. "Cooldown"]
 end
-
 -- ####################################################################################################################
 -- ##### Container: Slot Update #######################################################################################
 -- ####################################################################################################################
@@ -253,12 +694,8 @@ function ContainerMixin:SlotUpdate(itemSlot)
 	local id, slot = itemSlot.id, itemSlot.slot
 	local data = C_Container.GetContainerItemInfo(id, slot)
 
-	LUI:SetFrameBorderColor(itemSlot, module:RGBA("Border"))
-	if module:IsProfessionBag(id) then
-		LUI:SetFrameBorderColor(itemSlot, module:RGBA("Professions"))
-	end
-
 	itemSlot:SetHasItem(data ~= nil)
+	itemSlot.LUIHasItem = data ~= nil
 	itemSlot:SetReadable(data and data.isReadable)
 	itemSlot:UpdateCooldown(data ~= nil)
 	itemSlot:UpdateJunkItem(data and data.quality, data and data.hasNoValue)
@@ -318,30 +755,28 @@ function ContainerMixin:SlotUpdate(itemSlot)
 
 	-- Make sure to not keep name/quality info from previous item
 	itemSlot.name = nil
-	itemSlot.quality = nil
+	itemSlot.quality = data and data.quality
 	itemSlot.level = nil
 
-	-- Color Border according to quality
 	local itemLink = data and data.hyperlink
 	if itemLink then
 		itemSlot.name = data.itemName
-		itemSlot.quality = data.quality
-		
-		-- Get the item level for equippable items
-		if self.db.ItemLevel and C_Item.IsEquippableItem(itemLink) then
+
+		if self:GetOption("ItemLevel") and C_Item.IsEquippableItem(itemLink) then
 			itemSlot.level = GetDetailedItemLevelInfo(itemLink)
 		end
-
-		self:SetItemSlotBorderColor(itemSlot)
-		
 	end
-	
+
+	-- LUI's own item border follows item quality when that option is enabled.
+	-- The custom Item Border Color is only used when quality coloring is off.
+	self:SetItemSlotBorderColor(itemSlot)
+
 	if data then
 		SetItemButtonTexture(itemSlot, data.iconFileID)
 		SetItemButtonCount(itemSlot, itemSlot.level or data.stackCount)
 		SetItemButtonDesaturated(itemSlot, data.isLocked)
 
-		if self.db.ShowOverlay and itemLink then
+		if self:GetOption("ShowOverlay") and itemLink then
 			SetItemButtonOverlay(itemSlot, itemLink, data.quality, data.isBound)
 		else
 			ClearItemButtonOverlay(itemSlot)
@@ -350,20 +785,27 @@ function ContainerMixin:SlotUpdate(itemSlot)
 		itemSlot:Reset()
 	end
 
+	-- Reset may restore the template's normal border on an empty slot.
+	itemSlot:SetNormalTexture("")
+	local nativeBorder = itemSlot.IconBorder or _G[itemSlot:GetName().."IconBorder"]
+	if nativeBorder then nativeBorder:Hide() end
 	itemSlot:Show()
 end
 
 function ContainerMixin:SetItemSlotBorderColor(itemSlot)
-	if self:GetOption("ItemQuality") and itemSlot.quality and itemSlot.quality >= Enum.ItemQuality.Uncommon then
-		local r, g, b = GetItemQualityColor(itemSlot.quality)
-		LUI:SetFrameBorderColor(itemSlot, r, g, b)
-	elseif module:IsProfessionBag(itemSlot.id) then
-		LUI:SetFrameBorderColor(itemSlot, module:RGBA("Professions"))
-	else
-		LUI:SetFrameBorderColor(itemSlot, module:RGBA("Border"))
-	end
+    -- Empty slots have a backplate, but no item/quality border. Keep the skin
+    -- configured so a newly occupied slot can show its border without a reload.
+    module:SetSkinBorderShown(itemSlot, itemSlot.LUIHasItem ~= false)
+    if itemSlot.LUIHasItem == false then return end
+    if self:GetOption("ItemQuality") and itemSlot.quality ~= nil then
+        local r, g, b = GetItemQualityColor(itemSlot.quality)
+        module:SetSkinBorderColor(itemSlot, r, g, b, 1)
+    elseif module:IsProfessionBag(itemSlot.id) then
+        module:SetSkinBorderColor(itemSlot, module:RGBA("Professions"))
+    else
+        module:SetSkinBorderColor(itemSlot, module:RGBA("ItemBorder"))
+    end
 end
-
 function ContainerMixin:ItemLockUpdate(event_, id, slot)
 	if not slot or not self:IsValidID(id) or not self.itemList[id][slot] then
 		return
@@ -392,6 +834,10 @@ function ContainerMixin:BagUpdateEvent(idList)
 		end
 	end
 
+	-- Sorting moves items over multiple updates. Reapply the selected layout
+	-- after those updates instead of relying only on the initial option click.
+	if self.name == "Bags" then self:SetAnchors() end
+
 	-- Update Search Results if searching
 	if self.editbox:IsShown() then
 		self:SearchUpdate()
@@ -401,6 +847,33 @@ end
 -- ####################################################################################################################
 -- ##### Container: Set Anchors #######################################################################################
 -- ####################################################################################################################
+
+-- Keep the selected presentation independent of the native setting's update
+-- timing. Seed existing profiles once from their current sorting direction.
+function module:GetFillBagsFromBottom()
+    local db = module.db.profile.Bags
+    if db.FillFromBottom == nil then
+        db.FillFromBottom = not C_Container.GetSortBagsRightToLeft()
+    end
+    return db.FillFromBottom
+end
+
+function module:SetFillBagsFromBottom(value)
+    module.db.profile.Bags.FillFromBottom = not not value
+    module:SortBags()
+end
+
+function module:SortBags()
+    C_Container.SetSortBagsRightToLeft(not module:GetFillBagsFromBottom())
+    if module.bagSortTimer then module.bagSortTimer:Cancel() end
+    -- Let the native direction setting update before requesting a sort.
+    -- Coalesce quick clicks so an old request cannot sort the new selection.
+    module.bagSortTimer = C_Timer.NewTimer(0, function()
+        module.bagSortTimer = nil
+        C_Container.SortBags()
+        module:Refresh()
+    end)
+end
 
 -- This function will set all itemslot anchors and the container's dimensions based on that.
 function ContainerMixin:SetAnchors()
@@ -415,13 +888,19 @@ function ContainerMixin:SetAnchors()
 	local padding = self:GetOption("Padding")
 	local spacing = self:GetOption("Spacing")
 	local rowSize = self:GetOption("RowSize")
+	-- Blizzard's bottom-fill direction chooses later bags first, but fills
+	-- each bag from its first slot. Mirror slots within each bag so a partly
+	-- filled bag joins the full bags below instead of leaving a gap between.
+	-- Keep the stored lists and real slot IDs intact for updates and clicks.
+	local reverseSlots = self.name == "Bags" and module:GetFillBagsFromBottom()
 	for i = 1, self.NUM_BAG_IDS do
 		local id = self.BAG_ID_LIST[i]
 		if self:GetOption("BagNewline") then
 			index = 0
 		end
 		for j = 1, #self.itemList[id] do
-			local itemSlot = self.itemList[id][j]
+			local slotIndex = reverseSlots and (#self.itemList[id] - j + 1) or j
+			local itemSlot = self.itemList[id][slotIndex]
 			-- Make sure to clear points to prevent errors.
 			itemSlot:ClearAllPoints()
 			-- ItemSlots beyond bagCount are hidden, so we don't count them
@@ -470,6 +949,7 @@ function ContainerMixin:SetAnchors()
 	self.background:SetPoint("BOTTOM", lineAnchor, "BOTTOM", 0, -padding)
 	self.background:SetPoint("TOP", rightAnchor, "TOP", 0, LAYOUT_OFFSET + padding)
 	-- Then set the size of the container frame to be equal to the background.
+	-- The decorative border intentionally extends outside this area.
 	self:SetSize(self.background:GetWidth(), self.background:GetHeight())
 end
 
@@ -548,9 +1028,17 @@ function module:CreateSlot(name, parent, template)
 
 	local count = button.Count or _G[name.."Count"]
 	if count then
-		module:RefreshFontString(count, "Stack")
+		module:RefreshBagFontString(count, "Stack")
 	end
 
+	-- LUI owns quality coloring; do not stack Blizzard's border underneath it.
+	local nativeBorder = button.IconBorder or _G[name.."IconBorder"]
+	if nativeBorder then nativeBorder:Hide() end
+
+	module:ApplyItemStyle(button)
+	if parent.slotList and parent.container then
+		module:SetToolbarSlotBorderColor(button, parent.container)
+	end
 	return button
 end
 
@@ -566,10 +1054,9 @@ function module:CreateNewContainer(name, obj)
 	frame:SetClampedToScreen(true)
 	frame:SetSize(600, 600)
 
-	-- Background frame
+	-- Layout frame for the main bag surface. Visual layers are owned by Bags.
 	local bgFrame = CreateFrame("Frame", nil, frame)
-	bgFrame:SetFrameLevel(frame:GetParent():GetFrameLevel()+1)
-	bgFrame:SetClampedToScreen(true)
+	bgFrame:SetFrameLevel(frame:GetFrameLevel())
 	frame.background = bgFrame
 
 	-- Close Button
@@ -604,7 +1091,7 @@ function module:CreateNewContainer(name, obj)
 	end
 	---@cast frame ContainerMixin
 
-	frame.db = module.db.profile[name]
+	frame.profileKey = name
 
 	--Set up scripts
 	frame:SetScript("OnShow", frame.OnShow)
@@ -666,110 +1153,106 @@ end
 -- ##### Module Refresh ###############################################################################################
 -- ####################################################################################################################
 function module:Refresh()
-	for _, container in pairs(containerStorage) do
-			-- Refresh Settings
-			container:SetScale(container:GetOption("Scale"))
-			container:SetPosition()
-			container:SetAnchors()
+    if not module.db or not module.db.profile then return end
+    module:RefreshMedia()
 
-			container.editbox:SetMaxLetters(container:GetOption("RowSize") * 5)
-			module:RefreshFontString(container.editbox, "Bags")
-			container.searchText:SetText(module:ColorText(SEARCH, "Search"))
-			if container.gold then
-				module:RefreshFontString(container.gold, "Bags")
-				module:RefreshFontString(container.currency, "Bags")
-			end
-			if container.utilBar then
-				container.utilBar:ClearAllPoints()
-				if container:GetOption("BagBar") then
-					container.utilBar:SetPoint("LEFT", container.bagsBar, "RIGHT", 4, 0)
-				else
-					container.utilBar:SetPoint("BOTTOMLEFT", container, "TOPLEFT", 0, 2)
-				end
-			end
+    for _, container in pairs(containerStorage) do
+        local scale = tonumber(container:GetOption("Scale")) or 1
+        container:SetScale(scale)
+        container:SetPosition()
+        container:SetAnchors()
 
-			-- Refresh Backdrops
-			module:RefreshBackdrops()
-			LUI:ApplyFrameBackdrop(container.background, module.bagBackdrop)
-			-- Refresh item slots
-			for i = 1, container.NUM_BAG_IDS do
-				local id = container.BAG_ID_LIST[i]
-				for j = 1, #container.itemList[id] do
-					local slot = container.itemList[id][j]
-					container:SlotUpdate(slot)
-					LUI:ApplyFrameBackdrop(slot, module.itemBackdrop)
-					local count = slot.Count or _G[slot:GetName().."Count"]
-					if count then module:RefreshFontString(count, "Stack") end
-				end
-			end
+        container.editbox:SetMaxLetters((tonumber(container:GetOption("RowSize")) or 16) * 5)
+        module:RefreshBagFontString(container.editbox, "Bags")
 
-			-- Refresh Toolbars
-			for _, toolbar in pairs(container.toolbars) do
-				LUI:ApplyFrameBackdrop(toolbar.background, module.bagBackdrop)
-				toolbar:SetAnchors()
-				if toolbar == container.bagsBar then
-					toolbar:SetShown(container:GetOption("BagBar"))
-				end
+        container.searchText:ClearAllPoints()
+        container.searchText:SetPoint("TOPLEFT", container, tonumber(container:GetOption("Padding")) or 0, -10)
+        container.searchText:SetPoint("TOPRIGHT", container, "TOPRIGHT", -40, 0)
+        container.searchText:SetText(SEARCH)
 
-				for i = 1, #toolbar.slotList do
-				local slot = toolbar.slotList[i]
-					LUI:ApplyFrameBackdrop(slot, module.itemBackdrop)
-				end
-			end
+        if container.gold then
+            module:RefreshBagFontString(container.gold, "Bags")
+            module:RefreshBagFontString(container.currency, "Bags")
+        end
 
-			-- Refresh Colors
-			module:RefreshColors()
-			container.forceRefresh = false
-	end
-end
+        if container.utilBar then
+            container.utilBar:ClearAllPoints()
+            if container:GetOption("BagBar") and container.bagsBar then
+                container.utilBar:SetPoint("LEFT", container.bagsBar, "RIGHT", 4, 0)
+            else
+                container.utilBar:SetPoint("BOTTOMLEFT", container, "TOPLEFT", 0, 2)
+            end
+        end
 
-function module:RefreshBackdrops()
-	local db = module.db.profile.Textures
-	-- Bag Backdrop
-	module.bagBackdrop = {
-		bgFile = Media:Fetch("background", db.BackgroundTex),
-		edgeFile = Media:Fetch("border", db.BorderTex),
-		edgeSize = db.BorderSize, insets = { left = 3, right = 3, top = 3, bottom = 3 }
-	}
-	-- Item Backdrop
-	module.itemBackdrop = {
-		bgFile = Media:Fetch("background", db.BackgroundTex),
-		edgeFile = Media:Fetch("border", db.BorderTex),
-		edgeSize = db.BorderSize, insets = { left = 3, right = 3, top = 3, bottom = 3 },
-	}
+        module:ApplyBagFrameStyle(container.background)
+
+        for i = 1, container.NUM_BAG_IDS do
+            local id = container.BAG_ID_LIST[i]
+            for j = 1, #container.itemList[id] do
+                local slot = container.itemList[id][j]
+                module:ApplyItemStyle(slot)
+                container:SlotUpdate(slot)
+                local count = slot.Count or _G[slot:GetName().."Count"]
+                if count then module:RefreshBagFontString(count, "Stack") end
+            end
+        end
+
+        for _, toolbar in pairs(container.toolbars) do
+            module:ApplyBagFrameStyle(toolbar.background)
+            toolbar:SetAnchors()
+            if toolbar == container.bagsBar then
+                toolbar:SetShown(container:GetOption("BagBar"))
+            end
+            for i = 1, #toolbar.slotList do
+                local slot = toolbar.slotList[i]
+                module:ApplyItemStyle(slot)
+                module:SetToolbarSlotBorderColor(slot, container)
+            end
+        end
+
+        container.forceRefresh = false
+    end
+
+    module:RefreshColors()
 end
 
 function module:RefreshColors()
-	for _, container in pairs(containerStorage) do
-		local r, g, b, a = module:RGBA("Background")
-		local mult = BACKGROUND_MULTIPLIER
-		LUI:SetFrameBackgroundColor(container.background, r * mult, g * mult, b * mult, a)
-		LUI:SetFrameBorderColor(container.background, module:RGBA("Border"))
+    for _, container in pairs(containerStorage) do
+        module:ApplyBackgroundStyle(container.background, "Background")
+        module:SetSkinBorderColor(container.background, module:RGBA("Border"))
 
-		for i = 1, container.NUM_BAG_IDS do
-			local id = container.BAG_ID_LIST[i]
-			for j = 1, #container.itemList[id] do
-				local itemSlot = container.itemList[id][j]
-				LUI:SetFrameBackgroundColor(itemSlot, module:RGBA("ItemBackground"))
-				container:SetItemSlotBorderColor(itemSlot)
-			end
-		end
+        module:ApplyBagTextColor(container.searchText, "Search")
+        module:ApplyBagTextColor(container.editbox, "Bags")
+        if container.gold then
+            module:ApplyBagTextColor(container.gold, "Bags")
+            module:ApplyBagTextColor(container.currency, "Bags")
+        end
 
-		-- Refresh Toolbars
-		for _, toolbar in pairs(container.toolbars) do
-			LUI:SetFrameBackgroundColor(toolbar.background, r * mult, g * mult, b * mult, a)
-			LUI:SetFrameBorderColor(toolbar.background, module:RGBA("Border"))
-			for i = 1, #toolbar.slotList do
-				local slot = toolbar.slotList[i]
-				LUI:SetFrameBackgroundColor(slot, module:RGBA("Background"))
-				LUI:SetFrameBorderColor(slot, module:RGBA("Border"))
-			end
-		end
+        for i = 1, container.NUM_BAG_IDS do
+            local id = container.BAG_ID_LIST[i]
+            for j = 1, #container.itemList[id] do
+                local itemSlot = container.itemList[id][j]
+                module:ApplyItemBackgroundStyle(itemSlot)
+                container:SetItemSlotBorderColor(itemSlot)
+                local count = itemSlot.Count or _G[itemSlot:GetName().."Count"]
+                module:ApplyBagTextColor(count, "Stack")
+            end
+        end
 
-	end
+        for _, toolbar in pairs(container.toolbars) do
+            module:ApplyBackgroundStyle(toolbar.background, "Background")
+            module:SetSkinBorderColor(toolbar.background, module:RGBA("Border"))
+            for i = 1, #toolbar.slotList do
+                local slot = toolbar.slotList[i]
+                module:ApplyItemBackgroundStyle(slot)
+                module:SetToolbarSlotBorderColor(slot, container)
+            end
+        end
+    end
 end
 
 function module:SetBags()
+	module:RefreshMedia()
 	module:CreateNewContainer("Bags", module.BagsContainer)
 	if not LUIBags.gold then
 		LUIBags:CreateTitleBar()
@@ -781,8 +1264,4 @@ end
 
 function module:RestoreBlizzardBagState()
 	if _G.LUIBags then _G.LUIBags:UnregisterAllEvents() end
-	if module.originalBackpackTokenWidth then
-		BackpackTokenFrame:SetWidth(module.originalBackpackTokenWidth)
-		module.originalBackpackTokenWidth = nil
-	end
 end

--- a/modules/bags/bags_init.lua
+++ b/modules/bags/bags_init.lua
@@ -40,6 +40,8 @@ module.defaults = {
 			BackgroundTex = "Blizzard Tooltip",
 			BorderTex = "Stripped_medium",
 			BorderSize = 5,
+			ItemBorderTex = "Stripped_medium",
+			ItemBorderSize = 3,
 		},
 		-- Fonts and Colors
 		Fonts = {
@@ -49,6 +51,7 @@ module.defaults = {
 		Colors = {
 			Search =         { r = 0.6,  g = 0.6,  b = 1,    a = 1,   t = "Class",      },
 			Border =         { r = 0.2,  g = 0.2,  b = 0.2,  a = 1,   t = "Individual", },
+			ItemBorder =     { r = 0.2,  g = 0.2,  b = 0.2,  a = 1,   t = "Individual", },
 			Background =     { r = 0.18, g = 0.18, b = 0.18, a = 0.8, t = "Class",      },
 			ItemBackground = { r = 0.18, g = 0.18, b = 0.18, a = 0.8, t = "Individual", },
 			Professions = { r = 0.1, g = 0.5, b = 0.2, a = 1, t = "Individual", },
@@ -61,6 +64,14 @@ module.defaults = {
 -- ####################################################################################################################
 -- ##### Framework Events #############################################################################################
 -- ####################################################################################################################
+
+-- Keep live frames and the options page on the newly active AceDB profile.
+-- This must exist before RegisterModule() so LUI registers the profile callbacks.
+function module:DBCallback()
+	if module:IsEnabled() and _G.LUIBags then
+		module:Refresh()
+	end
+end
 
 function module:OnInitialize()
 	LUI:RegisterModule(module)
@@ -95,11 +106,12 @@ function module:OnEnable()
 	if not tContains(UISpecialFrames, "LUIBags") then
 		tinsert(UISpecialFrames, "LUIBags")
 	end
-	_G.CloseAllBags()
 end
 
 function module:OnDisable()
-	_G.CloseAllBags()
+	if _G.LUIBags then
+		module.CloseBags()
+	end
 	self:UnhookAll()
 	module:RestoreBlizzardBagState()
 end

--- a/modules/bags/bags_init.lua
+++ b/modules/bags/bags_init.lua
@@ -36,6 +36,14 @@ module.defaults = {
 			X = 0,
 			Y = 0,
 		},
+		Bank = {
+			Enabled = false,
+			FillFromBottom = false,
+			RowSize = 14,
+			Spacing = 4,
+			ColumnGroupSpacing = 0,
+			Scale = 1,
+		},
 		Textures = {
 			BackgroundTex = "Blizzard Tooltip",
 			BorderTex = "Stripped_medium",
@@ -79,6 +87,7 @@ end
 
 function module:OnEnable()
 	module:SetBags()
+	module:EnableBank()
 
 	local origToggleBag = ToggleBag
 	local origOpenBag = OpenBag
@@ -109,6 +118,7 @@ function module:OnEnable()
 end
 
 function module:OnDisable()
+	module:DisableBank()
 	if _G.LUIBags then
 		module.CloseBags()
 	end

--- a/modules/bags/bank.lua
+++ b/modules/bags/bank.lua
@@ -1,0 +1,317 @@
+-- LUI presentation for the current Blizzard character/account bank. Blizzard
+-- retains the bank frame, tab data, item buttons, interaction scripts, money,
+-- access checks and confirmation dialogs. No legacy bank container IDs or
+-- character-bag sorting hooks are used here.
+local LUI = select(2, ...)
+local module = LUI:GetModule("Bags")
+local SLOT_SIZE, TOP_SPACE, BOTTOM_SPACE, SIDE_SPACE = 36, 63, 100, 26
+
+local function SavePoints(region)
+    local points = {}
+    for i = 1, region:GetNumPoints() do points[i] = {region:GetPoint(i)} end
+    return points
+end
+
+local function RestorePoints(region, points)
+    region:ClearAllPoints()
+    for _, point in ipairs(points) do region:SetPoint(unpack(point)) end
+end
+
+local function HideArtwork(state, region)
+    if not region then return end
+    if state.alphas[region] == nil then state.alphas[region] = region:GetAlpha() end
+    region:SetAlpha(0)
+end
+
+local function HideSkin(target)
+    module:HideSkinBorder(target)
+    local skin = target.LUIBagSkin
+    if skin then skin.tint:Hide(); skin.artwork:Hide() end
+end
+
+function module:IsBankStyleEnabled()
+    local db = module.db and module.db.profile and module.db.profile.Bank
+    return module.bankIntegrationEnabled and db and db.Enabled
+end
+
+function module:StyleBankItem(button)
+    if not module:IsBankStyleEnabled() then return end
+    local state = module.bankStyleState
+    if not state or state.restoring then return end
+    local saved = state.slots[button]
+    local icon = button.icon or button.Icon
+    if not saved then
+        saved = {width = button:GetWidth(), height = button:GetHeight()}
+        if icon then
+            saved.icon = icon
+            saved.iconPoints = SavePoints(icon)
+            saved.iconCoords = {icon:GetTexCoord()}
+        end
+        if button.Count then
+            saved.countFont = {button.Count:GetFont()}
+            saved.countColor = {button.Count:GetTextColor()}
+        end
+        state.slots[button] = saved
+    end
+    if not module:IsHooked(button, "Refresh") then
+        module:SecureHook(button, "Refresh", function(self) module:StyleBankItem(self) end)
+    end
+
+    button:SetSize(SLOT_SIZE, SLOT_SIZE)
+    if icon then
+        icon:ClearAllPoints()
+        icon:SetPoint("TOPLEFT", button, "TOPLEFT", 3, -3)
+        icon:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", -3, 3)
+        icon:SetTexCoord(.08, .92, .08, .92)
+    end
+    HideArtwork(state, button.Background)
+    HideArtwork(state, button.IconBorder)
+    HideArtwork(state, button:GetNormalTexture())
+
+    local info = button.itemInfo
+    button.LUIHasItem = info ~= nil
+    module:ApplyItemStyle(button)
+    local bags = module.db.profile.Bags
+    if info and bags.ItemQuality and info.quality ~= nil then
+        local r, g, b = C_Item.GetItemQualityColor(info.quality)
+        module:SetSkinBorderColor(button, r, g, b, 1)
+    end
+    if button.Count then module:RefreshBagFontString(button.Count, "Stack") end
+end
+
+-- Native bank tabs put an additive selection glow over the icon. Keep the
+-- native icon and socket without adding another outline in LUI presentation.
+function module:StyleBankTab(tab)
+    if not module:IsBankStyleEnabled() then return end
+    local state = module.bankStyleState
+    if not state or state.restoring or not tab.SelectedTexture then return end
+    if not state.tabs[tab] then
+        local highlight = tab:GetHighlightTexture()
+        state.tabs[tab] = {
+            selectionTexture = tab.SelectedTexture:GetTexture(),
+            highlight = highlight,
+            highlightAlpha = highlight and highlight:GetAlpha(),
+            highlightBlend = highlight and highlight:GetBlendMode(),
+        }
+    end
+    if not module:IsHooked(tab, "RefreshVisuals") then
+        module:SecureHook(tab, "RefreshVisuals", function(self) module:StyleBankTab(self) end)
+    end
+    -- Clearing the artwork also prevents the native alpha animation from
+    -- bringing the glow back. The animation and native selection state remain.
+    tab.SelectedTexture:SetTexture(nil)
+    local highlight = tab:GetHighlightTexture()
+    if highlight then highlight:SetBlendMode("BLEND"); highlight:SetAlpha(.15) end
+    HideSkin(tab)
+end
+
+function module:RefreshBankNames()
+    local state = module.bankStyleState
+    local frame, panel = state.frame, state.panel
+    local accountTab = frame:GetTabButton(frame.accountBankTabID)
+    if accountTab then
+        if not state.accountTab then
+            state.accountTab = accountTab
+            state.accountTabText = accountTab.tabText
+            state.accountTabLabel = accountTab:GetText()
+        end
+        accountTab.tabText = "Warband"
+        accountTab:SetText("Warband")
+        accountTab:UpdateTabWidth()
+    end
+    local title = panel:GetActiveBankType() == Enum.BankType.Account and "Warband" or BANK
+    frame:SetTitle(title)
+    if state.title then state.title:SetText(title) end
+end
+
+function module:RestoreBankStyle()
+    local state = module.bankStyleState
+    if not state or not state.active or state.restoring then return end
+    state.restoring = true
+    state.active = false
+    for region, alpha in pairs(state.alphas) do region:SetAlpha(alpha) end
+    wipe(state.alphas)
+    for button, saved in pairs(state.slots) do
+        HideSkin(button)
+        button.LUIHasItem = nil
+        button:SetSize(saved.width, saved.height)
+        if saved.icon then
+            RestorePoints(saved.icon, saved.iconPoints)
+            saved.icon:SetTexCoord(unpack(saved.iconCoords))
+        end
+        if button.Count and saved.countFont and saved.countFont[1] then
+            button.Count:SetFont(unpack(saved.countFont))
+            button.Count:SetTextColor(unpack(saved.countColor))
+        end
+    end
+    wipe(state.slots)
+    for tab, saved in pairs(state.tabs) do
+        HideSkin(tab)
+        tab.SelectedTexture:SetTexture(saved.selectionTexture)
+        if saved.highlight then
+            saved.highlight:SetBlendMode(saved.highlightBlend)
+            saved.highlight:SetAlpha(saved.highlightAlpha)
+        end
+    end
+    wipe(state.tabs)
+    if state.accountTab then
+        state.accountTab.tabText = state.accountTabText
+        state.accountTab:SetText(state.accountTabLabel)
+        state.accountTab:UpdateTabWidth()
+        state.accountTab = nil
+    end
+    state.background:Hide()
+    local frame, panel = state.frame, state.panel
+    frame:SetSize(state.frameWidth, state.frameHeight)
+    frame:SetScale(state.frameScale)
+    frame:SetAttribute("UIPanelLayout-width", state.layoutWidth)
+    frame:SetAttribute("UIPanelLayout-height", state.layoutHeight)
+    panel:SetSize(state.panelWidth, state.panelHeight)
+    if state.title then
+        RestorePoints(state.title, state.titlePoints)
+        state.title:SetText(state.titleText)
+    end
+    -- Let Blizzard regenerate its native slot anchors, including the correct
+    -- purchase/locked panel when there are no accessible item slots.
+    if panel:IsShown() then
+        panel:RefreshBankPanel()
+        panel:RequestTitleRefresh()
+    end
+    if frame:IsShown() then UpdateUIPanelPositions(frame) end
+    state.restoring = false
+end
+
+function module:RefreshBank()
+    if not module:IsBankStyleEnabled() then
+        module:RestoreBankStyle()
+        return
+    end
+    if not module:AttachBankHooks() then return end
+    local state = module.bankStyleState
+    if state.refreshing or state.restoring then return end
+    state.refreshing = true
+    local frame, panel = state.frame, state.panel
+    local db = module.db.profile.Bank
+    state.active = true
+
+    HideArtwork(state, frame.Background)
+    HideArtwork(state, frame.NineSlice)
+    HideArtwork(state, frame.PortraitContainer)
+    HideArtwork(state, panel.NineSlice)
+    HideArtwork(state, panel.EdgeShadows)
+    state.background:SetFrameLevel(frame:GetFrameLevel())
+    state.background:SetAllPoints(frame)
+    module:ApplyBagFrameStyle(state.background)
+    state.background:Show()
+    if state.title then
+        state.title:ClearAllPoints()
+        state.title:SetPoint("TOP", frame, "TOP", 0, -5)
+    end
+
+    -- Pool enumeration has no defined order. Lay out the actual bank slot IDs
+    -- in row order without replacing buttons or changing their item identity.
+    local buttons = {}
+    for button in panel:EnumerateValidItems() do buttons[#buttons + 1] = button end
+    -- Bank cleanup keeps using Blizzard's own action and confirmations. Only
+    -- the display direction changes: the first real slot appears at the end
+    -- of the grid in bottom-fill mode. No shared bag-sort setting is changed.
+    table.sort(buttons, function(a, b)
+        if db.FillFromBottom then
+            return a:GetContainerSlotID() > b:GetContainerSlotID()
+        end
+        return a:GetContainerSlotID() < b:GetContainerSlotID()
+    end)
+    local columns = math.max(8, math.min(20, tonumber(db.RowSize) or 14))
+    local spacing = math.max(0, math.min(12, tonumber(db.Spacing) or 4))
+    local groupSpacing = math.max(0, math.min(24, tonumber(db.ColumnGroupSpacing) or 0))
+    local width, height = state.panelWidth, state.panelHeight
+    -- The deposit button is centered. Its reagent checkbox and label extend
+    -- to the right, so reserve that same extent on both sides of the center.
+    local deposit = panel.AutoDepositFrame
+    local checkbox = deposit and deposit.IncludeReagentsCheckbox
+    if checkbox and checkbox:IsShown() then
+        local label = checkbox.Text
+        local labelWidth = label and math.max(label:GetWidth(), label:GetStringWidth()) or 0
+        local rightExtent = deposit.DepositButton:GetWidth() / 2 + 10 + checkbox:GetWidth() + 4 + labelWidth
+        width = math.max(width, 2 * (rightExtent + SIDE_SPACE))
+    end
+    if #buttons > 0 then
+        local rows = math.ceil(#buttons / columns)
+        local gridWidth = columns * SLOT_SIZE + (columns - 1) * spacing
+            + math.floor((columns - 1) / 2) * groupSpacing
+        width = math.max(width, 2 * SIDE_SPACE + gridWidth)
+        local gridLeft = (width - gridWidth) / 2
+        height = TOP_SPACE + rows * SLOT_SIZE + (rows - 1) * spacing + BOTTOM_SPACE
+        for index, button in ipairs(buttons) do
+            module:StyleBankItem(button)
+            button:ClearAllPoints()
+            local column = (index - 1) % columns
+            button:SetPoint("TOPLEFT", panel, "TOPLEFT",
+                gridLeft + column * (SLOT_SIZE + spacing) + math.floor(column / 2) * groupSpacing,
+                -TOP_SPACE - math.floor((index - 1) / columns) * (SLOT_SIZE + spacing))
+        end
+    end
+    for tab in panel.bankTabPool:EnumerateActive() do module:StyleBankTab(tab) end
+    module:RefreshBankNames()
+    local scale = state.frameScale * math.max(.5, math.min(1.5, tonumber(db.Scale) or 1))
+    local changed = frame:GetWidth() ~= width or frame:GetHeight() ~= height or frame:GetScale() ~= scale
+    panel:SetSize(width, height)
+    frame:SetSize(width, height)
+    frame:SetScale(scale)
+    frame:SetAttribute("UIPanelLayout-width", width)
+    frame:SetAttribute("UIPanelLayout-height", height)
+    if changed and frame:IsShown() then UpdateUIPanelPositions(frame) end
+    state.refreshing = false
+end
+
+function module:AttachBankHooks()
+    local frame = _G.BankFrame
+    local panel = frame and frame.BankPanel
+    if not panel or not panel.EnumerateValidItems or not panel.RefreshBankPanel then return false end
+    if not module.bankStyleState then
+        local title = _G.BankFrameTitleText
+        local background = CreateFrame("Frame", nil, frame)
+        background:Hide()
+        module.bankStyleState = {
+            frame = frame, panel = panel, background = background,
+            frameWidth = frame:GetWidth(), frameHeight = frame:GetHeight(), frameScale = frame:GetScale(),
+            panelWidth = panel:GetWidth(), panelHeight = panel:GetHeight(),
+            layoutWidth = frame:GetAttribute("UIPanelLayout-width"), layoutHeight = frame:GetAttribute("UIPanelLayout-height"),
+            title = title, titlePoints = title and SavePoints(title), titleText = title and title:GetText(),
+            alphas = {}, slots = {}, tabs = {},
+        }
+    end
+    for _, method in ipairs({"GenerateItemSlotsForSelectedTab", "RefreshAllItemsForSelectedTab", "RefreshBankPanel", "RefreshBankTabs", "RequestTitleRefresh"}) do
+        if not module:IsHooked(panel, method) then
+            module:SecureHook(panel, method, function() module:RefreshBank() end)
+        end
+    end
+    if not module:IsHooked(frame, "OnShow") then
+        module:SecureHookScript(frame, "OnShow", function() module:RefreshBank() end)
+    end
+    return true
+end
+
+function module:EnableBank()
+    module.bankIntegrationEnabled = true
+    if not module.bankLoadWatcher then
+        module.bankLoadWatcher = CreateFrame("Frame")
+        module.bankLoadWatcher:SetScript("OnEvent", function()
+            if module:AttachBankHooks() then
+                module.bankLoadWatcher:UnregisterEvent("ADDON_LOADED")
+                module:RefreshBank()
+            end
+        end)
+    end
+    if not module:IsHooked(module, "RefreshColors") then
+        module:SecureHook(module, "RefreshColors", function() module:RefreshBank() end)
+    end
+    if module:AttachBankHooks() then module:RefreshBank()
+    else module.bankLoadWatcher:RegisterEvent("ADDON_LOADED") end
+end
+
+function module:DisableBank()
+    module.bankIntegrationEnabled = false
+    if module.bankLoadWatcher then module.bankLoadWatcher:UnregisterAllEvents() end
+    module:RestoreBankStyle()
+end

--- a/modules/bags/templates.lua
+++ b/modules/bags/templates.lua
@@ -47,23 +47,27 @@ end
 -- ####################################################################################################################
 
 function module:CreateSearchBar(container)
-	local db = module.db.profile.Bags
+	local db = container:GetDB() or {}
 
 	-- Search Text
 	local search = container:CreateFontString(nil, "OVERLAY", "GameFonthighlightLarge")
-	local searchText = module:ColorText(SEARCH, "Search")
-	search:SetPoint("TOPLEFT", container, db.Padding, -10)
+	local searchText = SEARCH
+	search:SetPoint("TOPLEFT", container, tonumber(db.Padding) or 0, -10)
 	search:SetPoint("TOPRIGHT", -40, 0)
 	search:SetJustifyH("LEFT")
 	search:SetText(searchText)
+	local searchR, searchG, searchB, searchA = module:RGBA("Search")
+	if searchR and searchG and searchB then
+		search:SetTextColor(searchR, searchG, searchB, searchA or 1)
+	end
 
 	-- Search Editbox
 	local editbox = CreateFrame("EditBox", nil, container)
-	module:RefreshFontString(editbox, "Bags")
+	module:RefreshBagFontString(editbox, "Bags")
 	
 	editbox:SetHeight(32)
 	editbox:SetAutoFocus(false)
-	editbox:SetMaxLetters(db.RowSize * 5)
+	editbox:SetMaxLetters((tonumber(db.RowSize) or 16) * 5)
 	editbox:SetTextInsets(24, 0, 0, 0)
 	editbox:SetAllPoints(search)
 	editbox:Hide()

--- a/modules/bags/toolbars.lua
+++ b/modules/bags/toolbars.lua
@@ -55,10 +55,18 @@ function ToolbarMixin:SetAnchors()
 		end
 	end
 
+	self.background:ClearAllPoints()
+	if not firstAnchor or not previousAnchor then
+		self:Hide()
+		return
+	end
+
 	self.background:SetPoint("LEFT", firstAnchor, "LEFT", -padding, 0)
 	self.background:SetPoint("TOP", firstAnchor, "TOP", 0, padding)
 	self.background:SetPoint("BOTTOM", firstAnchor, "BOTTOM", 0, -padding)
 	self.background:SetPoint("RIGHT", previousAnchor, "RIGHT", padding, 0)
+	-- Keep the toolbar's outer frame in sync with Bag Border settings.
+	module:ApplyBagFrameStyle(self.background)
 
 	self:SetSize(self.background:GetWidth(), self.background:GetHeight())
 	self:Show()
@@ -80,13 +88,9 @@ function module:CreateToolBar(container, name)
 	toolBar:SetSize(1,1)
 
 	local bgFrame = CreateFrame("Frame", nil, toolBar)
-	--Force it to the lowest frame level to prevent layering issues
-	bgFrame:SetFrameLevel(toolBar:GetParent():GetFrameLevel())
-	bgFrame:SetClampedToScreen(true)
-
-	LUI:ApplyFrameBackdrop(bgFrame, module.bagBackdrop)
-	LUI:SetFrameBackgroundColor(bgFrame, module:RGBA("Background"))
-	LUI:SetFrameBorderColor(bgFrame, module:RGBA("Border"))
+	-- Toolbars share the outer bag frame style; their buttons use Item Border.
+	bgFrame:SetFrameLevel(toolBar:GetFrameLevel())
+	module:ApplyBagFrameStyle(bgFrame)
 
 	toolBar.slotList = {}
 	toolBar.nextIndex = 1
@@ -176,6 +180,15 @@ local function BarBarSlotOnEnter(self)
     GameTooltip:Show()
 end
 
+local function RefreshBagSlotStyle(button)
+	-- PaperDoll updates can restore Blizzard's normal and quality borders.
+	button:SetNormalTexture("")
+	local nativeBorder = button.IconBorder or _G[button:GetName().."IconBorder"]
+	if nativeBorder then nativeBorder:Hide() end
+	module:ApplyItemStyle(button)
+	module:SetToolbarSlotBorderColor(button, button:GetParent().container)
+end
+
 --- Create an ItemButton specific to the BagBar
 ---@param index number
 ---@param id number
@@ -223,23 +236,25 @@ function module:BagBarSlotButtonTemplate(index, id, name, parent)
 
 	button:RegisterEvent("INVENTORY_SEARCH_UPDATE")
 	button.UpdateTooltip = BagSlotButton_OnEnter
-	button.IconBorder:SetTexture("")
-	button.IconBorder:SetSize(1,1)
+	if button.IconBorder then button.IconBorder:Hide() end
 
 	button:SetScript("OnEvent", function(self, event, ...)
 		if event == "BAG_UPDATE_DELAYED" then
 			_G.PaperDollItemSlotButton_Update(self)
-			LUI:SetFrameBorderColor(self, module:RGBA("Border"))
+			RefreshBagSlotStyle(self)
 		elseif event == "INVENTORY_SEARCH_UPDATE" then
 			self:SetMatchesSearch(not C_Container.IsContainerFiltered(self.id));
 		else
 			PaperDollItemSlotButton_OnEvent(self, event, ...)
+			RefreshBagSlotStyle(self)
 		end
 	end)
 	button:SetScript("OnShow", PaperDollItemSlotButton_OnShow)
+	button:HookScript("OnShow", RefreshBagSlotStyle)
 	button:SetScript("OnHide", PaperDollItemSlotButton_OnHide)
 	button:SetScript("OnDragStart", function(self) PickupBagFromSlot(self.inventoryID) end)
 	button:SetScript("OnReceiveDrag", function(self) PutItemInBag(self.inventoryID) end)
+	RefreshBagSlotStyle(button)
 
 	return button
 end

--- a/modules/expbars/expbars.lua
+++ b/modules/expbars/expbars.lua
@@ -238,6 +238,8 @@ function module:SetEventHandling(enabled)
 		module.anchor:RegisterEvent("PLAYER_ENTERING_WORLD")
 		module.anchor:RegisterEvent("PLAYER_MAX_LEVEL_UPDATE")
 		module.anchor:RegisterEvent("UPDATE_FACTION")
+		module.anchor:RegisterEvent("FACTION_STANDING_CHANGED")
+		module.anchor:RegisterEvent("CHAT_MSG_COMBAT_FACTION_CHANGE")
 		module.anchor:RegisterEvent("ENABLE_XP_GAIN")
 		module.anchor:RegisterEvent("DISABLE_XP_GAIN")
 		module.anchor:RegisterEvent("ZONE_CHANGED")
@@ -251,6 +253,7 @@ function module:SetEventHandling(enabled)
 			bar:RegisterEvents()
 		end
 	else
+		module:ResetAutoReputation()
 		module.anchor:UnregisterAllEvents()
 		if statusTrackingBarManager and module:IsHooked(statusTrackingBarManager, "UpdateBarsShown") then
 			module:Unhook(statusTrackingBarManager, "UpdateBarsShown")
@@ -387,6 +390,8 @@ function module:SetMainBar()
 	module.secondaryMover = CreateMover(secondaryAnchor, "Experience Bar 2 - Drag to move")
 
 	anchor:SetScript("OnEvent", function(_, event, ...)
+		module:HandleAutoReputationEvent(event, ...)
+		if event == "FACTION_STANDING_CHANGED" or event == "CHAT_MSG_COMBAT_FACTION_CHANGE" then return end
 		module:UpdateMainBarVisibility(event, ...)
 	end)
 
@@ -537,6 +542,7 @@ function module:RefreshColors()
 end
 
 function module:Refresh()
+	module:ResetAutoReputation()
 	local db = module.db.profile
 	if not module.anchor or not module.secondaryAnchor then return end
 

--- a/modules/expbars/expbars_init.lua
+++ b/modules/expbars/expbars_init.lua
@@ -37,6 +37,7 @@ module.defaults = {
 		SecondaryRelativePoint = "BOTTOM",
 		ShowText = true,
 		ShowAzerite = true,
+		AutoWatchReputation = false,
 		Precision = 2,
 		TextX = -2,
 		TextY = 0,

--- a/modules/expbars/reputation.lua
+++ b/modules/expbars/reputation.lua
@@ -22,6 +22,136 @@ local SHORT_REPUTATION_NAMES = {
 
 local C_Reputation = C_Reputation
 
+-- Positive chat messages establish the direction of a change; the structured
+-- standing event supplies its faction ID. Do not compare its standing with
+-- GetFactionDataByID: these can update at different times and use different
+-- values for renown/paragon. No faction headers or reputation filters are changed.
+local gainPatterns
+
+local function MakeGainPattern(text)
+	local pattern, index, argument, captures = "^", 1, 0, 0
+	while index <= #text do
+		local rest = text:sub(index)
+		local token, position, kind = rest:match("^(%%(%d+)%$[-+ #0]*%d*%.?%d*([sdifgu]))")
+		if not token then token, kind = rest:match("^(%%[-+ #0]*%d*%.?%d*([sdifgu]))") end
+		if token then
+			argument = argument + 1
+			local number = tonumber(position) or argument
+			if number == 1 and kind == "s" then
+				pattern = pattern .. "(.+)"
+				captures = captures + 1
+			else
+				pattern = pattern .. ".-"
+			end
+			index = index + #token
+		elseif rest:sub(1, 2) == "%%" then
+			pattern = pattern .. "%%"
+			index = index + 2
+		else
+			pattern = pattern .. text:sub(index, index):gsub("(%W)", "%%%1")
+			index = index + 1
+		end
+	end
+	if captures == 1 then return pattern .. "$" end
+end
+
+local function GetGainFaction(message)
+	if issecretvalue(message) or type(message) ~= "string" then return end
+	if not gainPatterns then
+		gainPatterns = {}
+		-- Blizzard provides localized formats, including account-wide and bonus
+		-- variants. Only INCREASED messages qualify; losses and rank notices do not.
+		for key, value in pairs(_G) do
+			if type(key) == "string" and key:match("^FACTION_STANDING_INCREASED")
+				and type(value) == "string" then
+				local pattern = MakeGainPattern(value)
+				if pattern then gainPatterns[#gainPatterns + 1] = pattern end
+			end
+		end
+	end
+	for _, pattern in ipairs(gainPatterns) do
+		local name = message:match(pattern)
+		if name then return name end
+	end
+end
+
+function module:ResetAutoReputation()
+	if self.autoReputationTimer then self.autoReputationTimer:Cancel() end
+	self.autoReputationTimer = nil
+	self.autoReputationBatch = nil
+end
+
+local function AddFaction(batch, data)
+	if not data or issecretvalue(data.factionID) or issecretvalue(data.name) then return end
+	if type(data.factionID) ~= "number" or data.factionID <= 0 or type(data.name) ~= "string" then return end
+	if data.isHeader and not data.isHeaderWithRep then return end
+	-- Ambiguous localized names must not silently select a different faction.
+	local previous = batch.factions[data.name]
+	if previous == nil or previous == data.factionID then
+		batch.factions[data.name] = data.factionID
+	else
+		batch.factions[data.name] = false
+	end
+end
+
+local function ApplyAutoReputation(batch)
+	if module.autoReputationBatch ~= batch then return end
+	module.autoReputationTimer = nil
+	if not module:IsEnabled() or module.db.profile ~= batch.profile
+		or not module.db.profile.AutoWatchReputation then
+		module:ResetAutoReputation()
+		return
+	end
+	batch.factions = {}
+	for id in pairs(batch.ids) do AddFaction(batch, C_Reputation.GetFactionDataByID(id)) end
+	-- This also handles gains for an already listed faction if its standing
+	-- event was not emitted. Collapsed factions are resolved by their event ID.
+	for index = 1, C_Reputation.GetNumFactions() do
+		AddFaction(batch, C_Reputation.GetFactionDataByIndex(index))
+	end
+	local id = batch.factions[batch.names[#batch.names]]
+	if id then
+		module.autoReputationBatch = nil
+		local watched = C_Reputation.GetWatchedFactionData()
+		if not watched or watched.factionID ~= id then C_Reputation.SetWatchedFactionByID(id) end
+		module:UpdateMainBarVisibility()
+	elseif #batch.names > 0 and batch.attempt < 3 then
+		batch.attempt = batch.attempt + 1
+		module.autoReputationTimer = C_Timer.NewTimer(.15, function() ApplyAutoReputation(batch) end)
+	else
+		module.autoReputationBatch = nil
+	end
+end
+
+function module:HandleAutoReputationEvent(event, value)
+	if event == "PLAYER_ENTERING_WORLD" then self:ResetAutoReputation(); return end
+	if not self:IsEnabled() or not self.db.profile.AutoWatchReputation then
+		self:ResetAutoReputation()
+		return
+	end
+	local name, id
+	if event == "CHAT_MSG_COMBAT_FACTION_CHANGE" then
+		name = GetGainFaction(value)
+		if not name then return end
+	elseif event == "FACTION_STANDING_CHANGED" then
+		if issecretvalue(value) or type(value) ~= "number" or value <= 0 then return end
+		id = value
+	else
+		return
+	end
+	local batch = self.autoReputationBatch
+	if not batch or batch.profile ~= self.db.profile then
+		self:ResetAutoReputation()
+		batch = { profile = self.db.profile, names = {}, ids = {}, attempt = 1 }
+		self.autoReputationBatch = batch
+	end
+	if name then batch.names[#batch.names + 1] = name end
+	if id then batch.ids[id] = true end
+	if not self.autoReputationTimer then
+		self.autoReputationTimer = C_Timer.NewTimer(.15, function() ApplyAutoReputation(batch) end)
+	end
+end
+
 local function GetWatchedFactionInfo()
 	local data = C_Reputation.GetWatchedFactionData()
 	if not data then return end

--- a/modules/infotext/clock.lua
+++ b/modules/infotext/clock.lua
@@ -224,7 +224,7 @@ function element.OnTooltipShow(GameTooltip)
 			local name, _, reset, difficulty, locked, extended, _,
 					isRaid, maxPlayers, _, maxBosses, defeatedBosses = GetSavedInstanceInfo(i)
 			if isRaid and (locked or extended) then
-				local localizedDiff = GetLocalizedDifficulty(difficulty)
+				local localizedDiff = GetLocalizedDifficulty(difficulty) or ""
 				local r, g, b = 1, 1, 1
 				if extended then r, g, b = 0.5, 1, 0.5 end
 				oneraid = OneRaidCheck(oneraid)

--- a/modules/infotext/clock.lua
+++ b/modules/infotext/clock.lua
@@ -7,30 +7,32 @@
 ---@class LUIAddon
 local LUI = select(2, ...)
 local L = LUI.L
+
 ---@class InfotextModule
 local module = LUI:GetModule("Infotext")
 local element = module:NewElement("Clock", "AceEvent-3.0", "AceHook-3.0")
 LUI.Profiler.TraceScope(module, "Clock", "Infotext", 2)
+
 -- local copies
 local gsub, format, tonumber, date = gsub, format, tonumber, date
 local GetNumSavedWorldBosses = _G.GetNumSavedWorldBosses
 local GetSavedWorldBossInfo = _G.GetSavedWorldBossInfo
 local GetSavedInstanceInfo = _G.GetSavedInstanceInfo
 local GetNumSavedInstances = _G.GetNumSavedInstances
-local TimeBreakDown = _G.ChatFrameUtil.TimeBreakDown
+local TimeBreakDown = _G.ChatFrame_TimeBreakDown
 local GetInstanceInfo = _G.GetInstanceInfo
-local GetDifficultyInfo = _G.GetDifficultyInfo
 local GameTimeFrame = _G.GameTimeFrame
 local InGuildParty = _G.InGuildParty
 local IsInInstance = _G.IsInInstance
 local GetGameTime = _G.GetGameTime
 local GetCVarBool = _G.GetCVarBool
+
 -- local variables
 local cvarLocal, cvarMilitary -- Cache containing CVars
 local guildParty         -- If there's a G or not in the text
-local instanceInfo       -- Compact instance tag next to the clock.
-local instanceName, instanceTooltip -- Full instance details for the tooltip.
+local instanceInfo       -- Any instance tag would go in this.
 local invitesPending = false
+
 -- constants
 local GAMETIME_TOOLTIP_TOGGLE_CALENDAR = _G.GAMETIME_TOOLTIP_TOGGLE_CALENDAR
 local TIMEMANAGER_TOOLTIP_LOCALTIME = _G.TIMEMANAGER_TOOLTIP_LOCALTIME
@@ -42,17 +44,48 @@ local CVAR_MILITARY = "timeMgrUseMilitaryTime"
 local CVAR_LOCAL = "timeMgrUseLocalTime"
 
 local CLOCK_UPDATE_TIME = 1
-local INSTANCE_TEXT_GAP = 6
+
+--Instance Difficulty constants
+--local TAG_GUILD_GROUP = " |cff66c7ffG|r"
 local RAID_INFO_WORLD_BOSS = _G.RAID_INFO_WORLD_BOSS
 
--- Keep known modes compact without relabeling special modes as Normal.
-local SHORT_DIFFICULTIES = {
-	[1] = "N", [2] = "HC", -- Dungeons
-	[3] = "N", [4] = "N", [5] = "HC", [6] = "HC", -- Legacy raids
-	[7] = "LFR", [8] = "M+", [9] = "N",
-	[14] = "N", [15] = "HC", [16] = "M", [17] = "LFR", -- Raids
-	[23] = "M", [24] = "TW", [33] = "TW",
-	[233] = "MFlex", -- Mythic - Flexible Raiding (Lairs)
+-- Do not localize those strings. All of them have an associated localized InfoClock_Instance_* entry
+-- List as per  https://wowpedia.fandom.com/wiki/DifficultyID
+local INSTANCE_DIFFICULTY_FORMAT = {
+	[1]  = "Normal",    -- 5man Normal
+	[2]  = "Heroic",    -- 5man Heroic
+	[3]  = "Normal",    -- 10man Normal (Legacy)
+	[4]  = "Normal",    -- 25man Normal (Legacy)
+	[5]  = "Heroic",    -- 10man Heroic (Legacy)
+	[6]  = "Heroic",    -- 25man Heroic (Legacy)
+	[7]  = "LFR",       -- 25man Raid Finder (Legacy)
+	[8]  = "Mythic", 	-- 5man Mythic Keystone / Challenge Mode 
+	[9]  = "Normal",    -- 40man Normal
+	[11] = "Heroic",    -- 3man Heroic Scenario
+	[12] = "Normal",    -- 3man Scenario
+	[14] = "Normal",    -- Flexible Normal
+	[15] = "Heroic",    -- Flexible Heroic
+	[16] = "Mythic",    -- 20man Mythic
+	[17] = "LFR",       -- Flexible Raid Finder
+	[18] = "Event",     -- Event Party
+	[19] = "Event",     -- Event Raid
+	[20] = "Event",     -- Event Scenario
+	[23] = "Mythic",    -- 5man Mythic
+	[24] = "Timewalk",  -- Timewalking Dungeons
+	[25] = "Event",     -- World PVP Scenario
+	[29] = "Event",     -- PvEvP Scenario
+	[30] = "Event",     -- Event
+	[32] = "Event",     -- World PVP Scenario
+	[33] = "Timewalk",  -- Timewalking Raid
+	[34] = "Normal",    -- PvP
+	[38] = "Normal",    -- Normal Scenario
+	[39] = "Heroic",    -- Heroic Scenario
+	[40] = "Mythic",    -- Mythic Scenario
+	[45] = "Heroic",    -- PvP Scenario (DisplayHeroic)
+	[147] = "Normal",    -- Normal Warfronts
+	[149] = "Heroic",    -- Heroic Warfronts
+	[150] = "Normal",   -- Normal Party
+	[151] = "Timewalk", -- Timewalking LFR
 }
 
 local COLOR_CODES = {
@@ -60,10 +93,15 @@ local COLOR_CODES = {
 	Normal = "|cff00ff00",
 	Heroic = "|cffff0000",
 	LFR = "|cffaaaaaa",
+	Mythic = "|cffff0000",
+	Event = "|cffaaaaaa",
+	Timewalk = "|cffaaaaaa",
 }
+
 -- ####################################################################################################################
 -- ##### Module Functions #############################################################################################
 -- ####################################################################################################################
+
 --First we format the secs into a day/hour/minute format. The leading space is necessary.
 --Then we remove spaces followed by a 0, such as 0d or 0h. Those extra spaces are then trimmed.
 local function formatTime(sec)
@@ -71,6 +109,7 @@ local function formatTime(sec)
 	timeLeft = gsub(timeLeft, L["InfoClock_LockoutTimeLeftGsub_Format"], "")
 	return timeLeft:trim()
 end
+
 local function OneRaidCheck(bool)
 	if not bool then
 		GameTooltip:AddLine(" ")
@@ -78,119 +117,58 @@ local function OneRaidCheck(bool)
 	end
 	return true
 end
+
 local function GetLocalizedDifficulty(difficulty)
-	local name, instanceType, isHeroic, isChallengeMode, displayHeroic, displayMythic, _, isLFR,
-		minPlayers, maxPlayers = GetDifficultyInfo(difficulty)
-	if not name then return end
-	local colorCode = COLOR_CODES.Normal
-	if isLFR then
-		colorCode = COLOR_CODES.LFR
-	elseif isHeroic or isChallengeMode or displayHeroic or displayMythic then
-		colorCode = COLOR_CODES.Heroic
-	end
-	local shortName = SHORT_DIFFICULTIES[difficulty]
-	if not shortName then
-		if isLFR then
-			shortName = "LFR"
-		elseif isChallengeMode then
-			shortName = "M+"
-		elseif displayMythic then
-			-- Use the API's size limits, not English text or the current roster size.
-			local isFlex = instanceType == "raid" and minPlayers and maxPlayers
-				and minPlayers > 0 and maxPlayers > minPlayers
-			shortName = isFlex and "MFlex" or "M"
-		elseif isHeroic or displayHeroic then
-			shortName = "HC"
-		else
-			shortName = name
-		end
-	end
-	return name, colorCode, shortName
+	local diff = INSTANCE_DIFFICULTY_FORMAT[difficulty]
+	if not diff then return end
+	
+	local LString = format("InfoClock_Instance_%s", diff)
+	return L[LString], COLOR_CODES[diff]
 end
 
-function element:UpdateInvites()
-	invitesPending = C_Calendar.GetNumPendingInvites() > 0
+if LUI.IsRetail then
+	function element:UpdateInvites()
+		invitesPending = (GameTimeFrame and GameTimeFrame.pendingCalendarInvites > 0) and true or false
+	end
+
+	function element:UpdateGuildParty()
+		--local TAG_GUILD_GROUP = " |cff66c7ffG|r"
+		guildParty = InGuildParty() and string.format(" %s%s|r", COLOR_CODES.Guild, L["InfoClock_Instance_Guild"]) or nil
+	end
 end
-function element:UpdateGuildParty()
-	guildParty = InGuildParty() and string.format(" %s%s|r", COLOR_CODES.Guild, L["InfoClock_Instance_Guild"]) or nil
-end
+
 function element:UpdateInstanceInfo()
 	local isInstance, instanceType = IsInInstance()
 	if isInstance then
-		local name, _, difficulty, _, _, _, _, _, groupSize = GetInstanceInfo()
-		local localizedDiff, colorCode, shortDiff = GetLocalizedDifficulty(difficulty)
+		local _, _, difficulty, _, _, _, _, _, groupSize = GetInstanceInfo()
+		local localizedDiff, colorCode = GetLocalizedDifficulty(difficulty)
 		if localizedDiff and (instanceType == "raid" or instanceType == "party") then
-			local sizeText = groupSize and groupSize > 0 and format("%d ", groupSize) or ""
-			instanceInfo = format("%s%s%s|r", sizeText, colorCode, shortDiff)
-			instanceName = name
-			instanceTooltip = format("%s%s%s|r", sizeText, colorCode, localizedDiff)
+			instanceInfo = string.format("%d %s%s|r", groupSize, colorCode, localizedDiff)
 			return
 		end
 	end
-	instanceInfo, instanceName, instanceTooltip = nil, nil, nil
+	instanceInfo = nil
 end
-function element:UpdateInstanceFont()
-	local frame = element:GetFrame()
-	if not frame or not frame.instanceText then return end
-	local text = frame.instanceText
-	text:SetFont(frame.text:GetFont())
-	text:SetTextColor(frame.text:GetTextColor())
-	text:SetShadowColor(frame.text:GetShadowColor())
-	text:SetShadowOffset(frame.text:GetShadowOffset())
-end
-function element:UpdateInstanceDisplay()
-	local frame = element:GetFrame()
-	if not frame or not frame.instanceText then return end
-	local text = frame.instanceText
-	if not invitesPending and module.db.profile.Clock.instanceDifficulty and instanceInfo then
-		text:SetText(format("[%s%s]", instanceInfo, guildParty or ""))
-		text:Show()
-		-- Include the separate tag in the clock's hover/click area without resizing it.
-		local width = text:GetUnboundedStringWidth()
-		if not issecretvalue(width) then
-			frame:SetHitRectInsets(-math.ceil(width) - INSTANCE_TEXT_GAP, 0, 0, 0)
-		end
-	else
-		text:SetText("")
-		text:Hide()
-		frame:SetHitRectInsets(0, 0, 0, 0)
-	end
-end
+
 -- luacheck: globals TimeManagerMilitaryTimeCheck TimeManagerLocalTimeCheck
 function element:UpdateCVar()
 	cvarMilitary = GetCVarBool(CVAR_MILITARY)
 	cvarLocal = GetCVarBool(CVAR_LOCAL)
-	if _G.TimeManagerMilitaryTimeCheck then _G.TimeManagerMilitaryTimeCheck:SetChecked(cvarMilitary) end
-	if _G.TimeManagerLocalTimeCheck then _G.TimeManagerLocalTimeCheck:SetChecked(cvarLocal) end
+
+	--HACK: Blizzard's TimeFrame checkboxes do not update when cvars are changed, so make sure they are up to date.
+	TimeManagerMilitaryTimeCheck:SetChecked((cvarMilitary) and true or false)
+	TimeManagerLocalTimeCheck:SetChecked((cvarLocal) and true or false)
 	-- Only Refresh the options if the option panel is loaded.
 	if element.RefreshOptionsPanel then
 		element:RefreshOptionsPanel()
 	end
 	element:UpdateClock()
 end
-function element:HookTimeManager()
-	if not _G.TimeManagerMilitaryTimeCheck or not _G.TimeManagerLocalTimeCheck
-		or element:IsHooked(_G.TimeManagerMilitaryTimeCheck, "OnClick") then return end
-	element:SecureHookScript(_G.TimeManagerMilitaryTimeCheck, "OnClick", "UpdateCVar")
-	element:SecureHookScript(_G.TimeManagerLocalTimeCheck, "OnClick", "UpdateCVar")
-	element:UpdateCVar()
-end
-function element:ADDON_LOADED(_, addonName)
-	if addonName == "Blizzard_TimeManager" then
-		element:HookTimeManager()
-		element:UnregisterEvent("ADDON_LOADED")
-	end
-end
 
-function element:CVAR_UPDATE(_, cvarName)
-	if cvarName == CVAR_MILITARY or cvarName == CVAR_LOCAL then
-		element:UpdateCVar()
-	end
-end
 function element:GetTime(useLocal)
 	local Hr, Min, PM
 	if useLocal then
-		Hr, Min = tonumber(date("%H")), tonumber(date("%M"))
+		Hr, Min = tonumber(date("%H")), date("%M")
 	else
 		Hr, Min = GetGameTime()
 	end
@@ -205,16 +183,17 @@ function element:GetTime(useLocal)
 
 	return format("%d:%.2d %s", Hr, Min, PM or ""):trim()
 end
+
 function element:UpdateClock()
 	if invitesPending then
 		element.text = L["InfoClock_InvitePending"]
 	else
-		-- Only the time determines the main display's width and saved anchor.
-		element.text = element:GetTime(cvarLocal)
+		local timeFormat = (module.db.profile.instanceDifficulty and instanceInfo) and "%s (%s%s)" or "%s"
+		element.text = format(timeFormat, element:GetTime(cvarLocal), instanceInfo or "", guildParty or "")
 	end
-	element:UpdateInstanceDisplay()
 	element:UpdateTooltip()
 end
+
 -- Click: Open Calendar Frame
 -- RightClick: Open Time Manager
 function element.OnClick(frame_, button)
@@ -224,89 +203,73 @@ function element.OnClick(frame_, button)
 		GameTimeFrame:Click()
 	end
 end
+
 -- ####################################################################################################################
 -- ##### Infotext Display #############################################################################################
 -- ####################################################################################################################
 
 function element.OnTooltipShow(GameTooltip)
 	element:TooltipHeader(TIMEMANAGER_TITLE)
+
 	--Display both set of times.
 	GameTooltip:AddDoubleLine(cvarLocal and TIMEMANAGER_TOOLTIP_LOCALTIME or TIMEMANAGER_TOOLTIP_REALMTIME,
 	                         element:GetTime(cvarLocal))
 	GameTooltip:AddDoubleLine(cvarLocal and TIMEMANAGER_TOOLTIP_REALMTIME or TIMEMANAGER_TOOLTIP_LOCALTIME,
 	                          element:GetTime(not cvarLocal))
-	local db = module.db.profile.Clock
-	if db.instanceDifficulty and instanceTooltip then
-		GameTooltip:AddLine(" ")
-		GameTooltip:AddLine(instanceName, module:RGB("Title"))
-		GameTooltip:AddLine(format("%s%s", instanceTooltip, guildParty or ""), 1, 1, 1)
-	end
+
+	local db = module.db.profile
 	local oneraid -- Used so we dont display "Saved Raids:" unless you are saved to at least one.
 	if db.showSavedRaids then
 		for i = 1, GetNumSavedInstances() do
 			local name, _, reset, difficulty, locked, extended, _,
 					isRaid, maxPlayers, _, maxBosses, defeatedBosses = GetSavedInstanceInfo(i)
 			if isRaid and (locked or extended) then
-				local localizedDiff = GetLocalizedDifficulty(difficulty) or ""
+				local localizedDiff = GetLocalizedDifficulty(difficulty)
 				local r, g, b = 1, 1, 1
 				if extended then r, g, b = 0.5, 1, 0.5 end
 				oneraid = OneRaidCheck(oneraid)
-				local nameFormat = format("%s |cffaaaaaa%s %s|r", name, maxPlayers, localizedDiff)
+				local nameFormat = format("%s |cffaaaaaa%s%s", name, maxPlayers, localizedDiff)
 				nameFormat = format("%s (%s/%s)", nameFormat, defeatedBosses, maxBosses)
 				GameTooltip:AddDoubleLine(nameFormat, formatTime(reset), 1,1,1, r,g,b)
 			end
 		end
 	end
 	--Check for World Bosses too
-	if db.showWorldBosses then
+	if LUI.IsRetail and db.showWorldBosses then
 		for i = 1, GetNumSavedWorldBosses() do
 			local name, _, reset = GetSavedWorldBossInfo(i)
 			oneraid = OneRaidCheck(oneraid)
-			GameTooltip:AddDoubleLine(format("%s |cffaaaaaa(%s)|r", name, RAID_INFO_WORLD_BOSS),
+			GameTooltip:AddDoubleLine(format("%s |cffaaaaaa(%s)", name, RAID_INFO_WORLD_BOSS),
 			                          formatTime(reset), 1,1,1, 1,1,1)
 		end
 	end
+
 	element:AddHint(GAMETIME_TOOLTIP_TOGGLE_CALENDAR, L["InfoClock_Hint_Right"])
 end
 
 -- ####################################################################################################################
 -- ##### Framework Events #############################################################################################
 -- ####################################################################################################################
-function element:OnCreate(frame)
-	-- The instance tag grows to the left; the clock keeps its own saved position.
-	frame.instanceText = frame:CreateFontString(nil, "OVERLAY")
-	frame.instanceText:SetPoint("RIGHT", frame.text, "LEFT", -INSTANCE_TEXT_GAP, 0)
-	frame.instanceText:SetJustifyH("RIGHT")
-	frame.instanceText:SetJustifyV("MIDDLE")
-	frame.instanceText:SetWordWrap(false)
-	frame.instanceText:Hide()
-	element:UpdateInstanceFont()
+
+function element:OnCreate()
 	-- Update tags that can be found next to the clock.
-	element:RegisterEvent("GUILD_PARTY_STATE_UPDATED", "UpdateGuildParty")
-	element:RegisterEvent("PLAYER_DIFFICULTY_CHANGED", "UpdateInstanceInfo")
+	if LUI.IsRetail then element:RegisterEvent("GUILD_PARTY_STATE_UPDATED", "UpdateGuildParty") end
+	if LUI.IsRetail then element:RegisterEvent("PLAYER_DIFFICULTY_CHANGED", "UpdateInstanceInfo") end
 	element:RegisterEvent("INSTANCE_GROUP_SIZE_CHANGED", "UpdateInstanceInfo")
 	element:RegisterEvent("PLAYER_ENTERING_WORLD", "UpdateInstanceInfo")
-	element:RegisterEvent("CHALLENGE_MODE_START", "UpdateInstanceInfo")
-	element:RegisterEvent("CHALLENGE_MODE_RESET", "UpdateInstanceInfo")
-	element:UpdateGuildParty()
+	if LUI.IsRetail then element:UpdateGuildParty() end
 	element:UpdateInstanceInfo()
+
 	-- Update cached CVar data.
+	element:SecureHookScript(TimeManagerMilitaryTimeCheck, "OnClick", "UpdateCVar")
+	element:SecureHookScript(TimeManagerLocalTimeCheck, "OnClick", "UpdateCVar")
 	element:UpdateCVar()
-	element:RegisterEvent("CVAR_UPDATE")
-	if C_AddOns.IsAddOnLoaded("Blizzard_TimeManager") then
-		element:HookTimeManager()
-	else
-		element:RegisterEvent("ADDON_LOADED")
+
+	if LUI.IsRetail then
+		-- Update calendar invites
+		element:RegisterEvent("CALENDAR_UPDATE_PENDING_INVITES", "UpdateInvites")
+		element:UpdateInvites()
 	end
 
-	element:RegisterEvent("CALENDAR_UPDATE_PENDING_INVITES", "UpdateInvites")
-	element:UpdateInvites()
-
 	element:AddUpdate("UpdateClock", CLOCK_UPDATE_TIME)
-end
-
-function element:RefreshSettings()
-	element:UpdateInstanceFont()
-	element:UpdateInstanceInfo()
-	element:UpdateClock()
 end

--- a/modules/infotext/clock.lua
+++ b/modules/infotext/clock.lua
@@ -7,32 +7,30 @@
 ---@class LUIAddon
 local LUI = select(2, ...)
 local L = LUI.L
-
 ---@class InfotextModule
 local module = LUI:GetModule("Infotext")
 local element = module:NewElement("Clock", "AceEvent-3.0", "AceHook-3.0")
 LUI.Profiler.TraceScope(module, "Clock", "Infotext", 2)
-
 -- local copies
 local gsub, format, tonumber, date = gsub, format, tonumber, date
 local GetNumSavedWorldBosses = _G.GetNumSavedWorldBosses
 local GetSavedWorldBossInfo = _G.GetSavedWorldBossInfo
 local GetSavedInstanceInfo = _G.GetSavedInstanceInfo
 local GetNumSavedInstances = _G.GetNumSavedInstances
-local TimeBreakDown = _G.ChatFrame_TimeBreakDown
+local TimeBreakDown = _G.ChatFrameUtil.TimeBreakDown
 local GetInstanceInfo = _G.GetInstanceInfo
+local GetDifficultyInfo = _G.GetDifficultyInfo
 local GameTimeFrame = _G.GameTimeFrame
 local InGuildParty = _G.InGuildParty
 local IsInInstance = _G.IsInInstance
 local GetGameTime = _G.GetGameTime
 local GetCVarBool = _G.GetCVarBool
-
 -- local variables
 local cvarLocal, cvarMilitary -- Cache containing CVars
 local guildParty         -- If there's a G or not in the text
-local instanceInfo       -- Any instance tag would go in this.
+local instanceInfo       -- Compact instance tag next to the clock.
+local instanceName, instanceTooltip -- Full instance details for the tooltip.
 local invitesPending = false
-
 -- constants
 local GAMETIME_TOOLTIP_TOGGLE_CALENDAR = _G.GAMETIME_TOOLTIP_TOGGLE_CALENDAR
 local TIMEMANAGER_TOOLTIP_LOCALTIME = _G.TIMEMANAGER_TOOLTIP_LOCALTIME
@@ -44,48 +42,17 @@ local CVAR_MILITARY = "timeMgrUseMilitaryTime"
 local CVAR_LOCAL = "timeMgrUseLocalTime"
 
 local CLOCK_UPDATE_TIME = 1
-
---Instance Difficulty constants
---local TAG_GUILD_GROUP = " |cff66c7ffG|r"
+local INSTANCE_TEXT_GAP = 6
 local RAID_INFO_WORLD_BOSS = _G.RAID_INFO_WORLD_BOSS
 
--- Do not localize those strings. All of them have an associated localized InfoClock_Instance_* entry
--- List as per  https://wowpedia.fandom.com/wiki/DifficultyID
-local INSTANCE_DIFFICULTY_FORMAT = {
-	[1]  = "Normal",    -- 5man Normal
-	[2]  = "Heroic",    -- 5man Heroic
-	[3]  = "Normal",    -- 10man Normal (Legacy)
-	[4]  = "Normal",    -- 25man Normal (Legacy)
-	[5]  = "Heroic",    -- 10man Heroic (Legacy)
-	[6]  = "Heroic",    -- 25man Heroic (Legacy)
-	[7]  = "LFR",       -- 25man Raid Finder (Legacy)
-	[8]  = "Mythic", 	-- 5man Mythic Keystone / Challenge Mode 
-	[9]  = "Normal",    -- 40man Normal
-	[11] = "Heroic",    -- 3man Heroic Scenario
-	[12] = "Normal",    -- 3man Scenario
-	[14] = "Normal",    -- Flexible Normal
-	[15] = "Heroic",    -- Flexible Heroic
-	[16] = "Mythic",    -- 20man Mythic
-	[17] = "LFR",       -- Flexible Raid Finder
-	[18] = "Event",     -- Event Party
-	[19] = "Event",     -- Event Raid
-	[20] = "Event",     -- Event Scenario
-	[23] = "Mythic",    -- 5man Mythic
-	[24] = "Timewalk",  -- Timewalking Dungeons
-	[25] = "Event",     -- World PVP Scenario
-	[29] = "Event",     -- PvEvP Scenario
-	[30] = "Event",     -- Event
-	[32] = "Event",     -- World PVP Scenario
-	[33] = "Timewalk",  -- Timewalking Raid
-	[34] = "Normal",    -- PvP
-	[38] = "Normal",    -- Normal Scenario
-	[39] = "Heroic",    -- Heroic Scenario
-	[40] = "Mythic",    -- Mythic Scenario
-	[45] = "Heroic",    -- PvP Scenario (DisplayHeroic)
-	[147] = "Normal",    -- Normal Warfronts
-	[149] = "Heroic",    -- Heroic Warfronts
-	[150] = "Normal",   -- Normal Party
-	[151] = "Timewalk", -- Timewalking LFR
+-- Keep known modes compact without relabeling special modes as Normal.
+local SHORT_DIFFICULTIES = {
+	[1] = "N", [2] = "HC", -- Dungeons
+	[3] = "N", [4] = "N", [5] = "HC", [6] = "HC", -- Legacy raids
+	[7] = "LFR", [8] = "M+", [9] = "N",
+	[14] = "N", [15] = "HC", [16] = "M", [17] = "LFR", -- Raids
+	[23] = "M", [24] = "TW", [33] = "TW",
+	[233] = "MFlex", -- Mythic - Flexible Raiding (Lairs)
 }
 
 local COLOR_CODES = {
@@ -93,15 +60,10 @@ local COLOR_CODES = {
 	Normal = "|cff00ff00",
 	Heroic = "|cffff0000",
 	LFR = "|cffaaaaaa",
-	Mythic = "|cffff0000",
-	Event = "|cffaaaaaa",
-	Timewalk = "|cffaaaaaa",
 }
-
 -- ####################################################################################################################
 -- ##### Module Functions #############################################################################################
 -- ####################################################################################################################
-
 --First we format the secs into a day/hour/minute format. The leading space is necessary.
 --Then we remove spaces followed by a 0, such as 0d or 0h. Those extra spaces are then trimmed.
 local function formatTime(sec)
@@ -109,7 +71,6 @@ local function formatTime(sec)
 	timeLeft = gsub(timeLeft, L["InfoClock_LockoutTimeLeftGsub_Format"], "")
 	return timeLeft:trim()
 end
-
 local function OneRaidCheck(bool)
 	if not bool then
 		GameTooltip:AddLine(" ")
@@ -117,58 +78,123 @@ local function OneRaidCheck(bool)
 	end
 	return true
 end
-
 local function GetLocalizedDifficulty(difficulty)
-	local diff = INSTANCE_DIFFICULTY_FORMAT[difficulty]
-	if not diff then return end
-	
-	local LString = format("InfoClock_Instance_%s", diff)
-	return L[LString], COLOR_CODES[diff]
+	local name, instanceType, isHeroic, isChallengeMode, displayHeroic, displayMythic, _, isLFR,
+		minPlayers, maxPlayers = GetDifficultyInfo(difficulty)
+	if not name then return end
+	local colorCode = COLOR_CODES.Normal
+	if isLFR then
+		colorCode = COLOR_CODES.LFR
+	elseif isHeroic or isChallengeMode or displayHeroic or displayMythic then
+		colorCode = COLOR_CODES.Heroic
+	end
+	local shortName = SHORT_DIFFICULTIES[difficulty]
+	if not shortName then
+		if isLFR then
+			shortName = "LFR"
+		elseif isChallengeMode then
+			shortName = "M+"
+		elseif displayMythic then
+			-- Use the API's size limits, not English text or the current roster size.
+			local isFlex = instanceType == "raid" and minPlayers and maxPlayers
+				and minPlayers > 0 and maxPlayers > minPlayers
+			shortName = isFlex and "MFlex" or "M"
+		elseif isHeroic or displayHeroic then
+			shortName = "HC"
+		else
+			shortName = name
+		end
+	end
+	return name, colorCode, shortName
 end
 
-if LUI.IsRetail then
-	function element:UpdateInvites()
-		invitesPending = (GameTimeFrame and GameTimeFrame.pendingCalendarInvites > 0) and true or false
-	end
-
-	function element:UpdateGuildParty()
-		--local TAG_GUILD_GROUP = " |cff66c7ffG|r"
-		guildParty = InGuildParty() and string.format(" %s%s|r", COLOR_CODES.Guild, L["InfoClock_Instance_Guild"]) or nil
-	end
+function element:UpdateInvites()
+	invitesPending = C_Calendar.GetNumPendingInvites() > 0
 end
-
+function element:UpdateGuildParty()
+	guildParty = InGuildParty() and string.format(" %s%s|r", COLOR_CODES.Guild, L["InfoClock_Instance_Guild"]) or nil
+end
 function element:UpdateInstanceInfo()
 	local isInstance, instanceType = IsInInstance()
 	if isInstance then
-		local _, _, difficulty, _, _, _, _, _, groupSize = GetInstanceInfo()
-		local localizedDiff, colorCode = GetLocalizedDifficulty(difficulty)
+		local name, _, difficulty, _, _, _, _, _, groupSize = GetInstanceInfo()
+		local localizedDiff, colorCode, shortDiff = GetLocalizedDifficulty(difficulty)
 		if localizedDiff and (instanceType == "raid" or instanceType == "party") then
-			instanceInfo = string.format("%d %s%s|r", groupSize, colorCode, localizedDiff)
+			local sizeText = groupSize and groupSize > 0 and format("%d ", groupSize) or ""
+			instanceInfo = format("%s%s%s|r", sizeText, colorCode, shortDiff)
+			instanceName = name
+			instanceTooltip = format("%s%s%s|r", sizeText, colorCode, localizedDiff)
 			return
 		end
 	end
-	instanceInfo = nil
+	instanceInfo, instanceName, instanceTooltip = nil, nil, nil
 end
-
+function element:UpdateInstanceFont()
+	local frame = element:GetFrame()
+	if not frame or not frame.instanceText then return end
+	local text = frame.instanceText
+	local fontFile, fontHeight, fontFlags = frame.text:GetFont()
+	if not fontFile or fontFile == "" then
+		fontFile, fontHeight, fontFlags = _G.GameFontNormal:GetFont()
+	end
+	text:SetFont(fontFile, fontHeight, fontFlags)
+	text:SetTextColor(frame.text:GetTextColor())
+	text:SetShadowColor(frame.text:GetShadowColor())
+	text:SetShadowOffset(frame.text:GetShadowOffset())
+end
+function element:UpdateInstanceDisplay()
+	local frame = element:GetFrame()
+	if not frame or not frame.instanceText then return end
+	local text = frame.instanceText
+	if not invitesPending and module.db.profile.Clock.instanceDifficulty and instanceInfo then
+		text:SetText(format("[%s%s]", instanceInfo, guildParty or ""))
+		text:Show()
+		-- Include the separate tag in the clock's hover/click area without resizing it.
+		local width = text:GetUnboundedStringWidth()
+		if not issecretvalue(width) then
+			frame:SetHitRectInsets(-math.ceil(width) - INSTANCE_TEXT_GAP, 0, 0, 0)
+		end
+	else
+		text:SetText("")
+		text:Hide()
+		frame:SetHitRectInsets(0, 0, 0, 0)
+	end
+end
 -- luacheck: globals TimeManagerMilitaryTimeCheck TimeManagerLocalTimeCheck
 function element:UpdateCVar()
 	cvarMilitary = GetCVarBool(CVAR_MILITARY)
 	cvarLocal = GetCVarBool(CVAR_LOCAL)
-
-	--HACK: Blizzard's TimeFrame checkboxes do not update when cvars are changed, so make sure they are up to date.
-	TimeManagerMilitaryTimeCheck:SetChecked((cvarMilitary) and true or false)
-	TimeManagerLocalTimeCheck:SetChecked((cvarLocal) and true or false)
+	if _G.TimeManagerMilitaryTimeCheck then _G.TimeManagerMilitaryTimeCheck:SetChecked(cvarMilitary) end
+	if _G.TimeManagerLocalTimeCheck then _G.TimeManagerLocalTimeCheck:SetChecked(cvarLocal) end
 	-- Only Refresh the options if the option panel is loaded.
 	if element.RefreshOptionsPanel then
 		element:RefreshOptionsPanel()
 	end
 	element:UpdateClock()
 end
+function element:HookTimeManager()
+	if not _G.TimeManagerMilitaryTimeCheck or not _G.TimeManagerLocalTimeCheck
+		or element:IsHooked(_G.TimeManagerMilitaryTimeCheck, "OnClick") then return end
+	element:SecureHookScript(_G.TimeManagerMilitaryTimeCheck, "OnClick", "UpdateCVar")
+	element:SecureHookScript(_G.TimeManagerLocalTimeCheck, "OnClick", "UpdateCVar")
+	element:UpdateCVar()
+end
+function element:ADDON_LOADED(_, addonName)
+	if addonName == "Blizzard_TimeManager" then
+		element:HookTimeManager()
+		element:UnregisterEvent("ADDON_LOADED")
+	end
+end
 
+function element:CVAR_UPDATE(_, cvarName)
+	if cvarName == CVAR_MILITARY or cvarName == CVAR_LOCAL then
+		element:UpdateCVar()
+	end
+end
 function element:GetTime(useLocal)
 	local Hr, Min, PM
 	if useLocal then
-		Hr, Min = tonumber(date("%H")), date("%M")
+		Hr, Min = tonumber(date("%H")), tonumber(date("%M"))
 	else
 		Hr, Min = GetGameTime()
 	end
@@ -183,17 +209,16 @@ function element:GetTime(useLocal)
 
 	return format("%d:%.2d %s", Hr, Min, PM or ""):trim()
 end
-
 function element:UpdateClock()
 	if invitesPending then
 		element.text = L["InfoClock_InvitePending"]
 	else
-		local timeFormat = (module.db.profile.instanceDifficulty and instanceInfo) and "%s (%s%s)" or "%s"
-		element.text = format(timeFormat, element:GetTime(cvarLocal), instanceInfo or "", guildParty or "")
+		-- Only the time determines the main display's width and saved anchor.
+		element.text = element:GetTime(cvarLocal)
 	end
+	element:UpdateInstanceDisplay()
 	element:UpdateTooltip()
 end
-
 -- Click: Open Calendar Frame
 -- RightClick: Open Time Manager
 function element.OnClick(frame_, button)
@@ -203,21 +228,23 @@ function element.OnClick(frame_, button)
 		GameTimeFrame:Click()
 	end
 end
-
 -- ####################################################################################################################
 -- ##### Infotext Display #############################################################################################
 -- ####################################################################################################################
 
 function element.OnTooltipShow(GameTooltip)
 	element:TooltipHeader(TIMEMANAGER_TITLE)
-
 	--Display both set of times.
 	GameTooltip:AddDoubleLine(cvarLocal and TIMEMANAGER_TOOLTIP_LOCALTIME or TIMEMANAGER_TOOLTIP_REALMTIME,
 	                         element:GetTime(cvarLocal))
 	GameTooltip:AddDoubleLine(cvarLocal and TIMEMANAGER_TOOLTIP_REALMTIME or TIMEMANAGER_TOOLTIP_LOCALTIME,
 	                          element:GetTime(not cvarLocal))
-
-	local db = module.db.profile
+	local db = module.db.profile.Clock
+	if db.instanceDifficulty and instanceTooltip then
+		GameTooltip:AddLine(" ")
+		GameTooltip:AddLine(instanceName, module:RGB("Title"))
+		GameTooltip:AddLine(format("%s%s", instanceTooltip, guildParty or ""), 1, 1, 1)
+	end
 	local oneraid -- Used so we dont display "Saved Raids:" unless you are saved to at least one.
 	if db.showSavedRaids then
 		for i = 1, GetNumSavedInstances() do
@@ -228,48 +255,62 @@ function element.OnTooltipShow(GameTooltip)
 				local r, g, b = 1, 1, 1
 				if extended then r, g, b = 0.5, 1, 0.5 end
 				oneraid = OneRaidCheck(oneraid)
-				local nameFormat = format("%s |cffaaaaaa%s%s", name, maxPlayers, localizedDiff)
+				local nameFormat = format("%s |cffaaaaaa%s %s|r", name, maxPlayers, localizedDiff)
 				nameFormat = format("%s (%s/%s)", nameFormat, defeatedBosses, maxBosses)
 				GameTooltip:AddDoubleLine(nameFormat, formatTime(reset), 1,1,1, r,g,b)
 			end
 		end
 	end
 	--Check for World Bosses too
-	if LUI.IsRetail and db.showWorldBosses then
+	if db.showWorldBosses then
 		for i = 1, GetNumSavedWorldBosses() do
 			local name, _, reset = GetSavedWorldBossInfo(i)
 			oneraid = OneRaidCheck(oneraid)
-			GameTooltip:AddDoubleLine(format("%s |cffaaaaaa(%s)", name, RAID_INFO_WORLD_BOSS),
+			GameTooltip:AddDoubleLine(format("%s |cffaaaaaa(%s)|r", name, RAID_INFO_WORLD_BOSS),
 			                          formatTime(reset), 1,1,1, 1,1,1)
 		end
 	end
-
 	element:AddHint(GAMETIME_TOOLTIP_TOGGLE_CALENDAR, L["InfoClock_Hint_Right"])
 end
 
 -- ####################################################################################################################
 -- ##### Framework Events #############################################################################################
 -- ####################################################################################################################
-
-function element:OnCreate()
+function element:OnCreate(frame)
+	-- The instance tag grows to the left; the clock keeps its own saved position.
+	frame.instanceText = frame:CreateFontString(nil, "OVERLAY")
+	frame.instanceText:SetPoint("RIGHT", frame.text, "LEFT", -INSTANCE_TEXT_GAP, 0)
+	frame.instanceText:SetJustifyH("RIGHT")
+	frame.instanceText:SetJustifyV("MIDDLE")
+	frame.instanceText:SetWordWrap(false)
+	frame.instanceText:Hide()
+	element:UpdateInstanceFont()
 	-- Update tags that can be found next to the clock.
-	if LUI.IsRetail then element:RegisterEvent("GUILD_PARTY_STATE_UPDATED", "UpdateGuildParty") end
-	if LUI.IsRetail then element:RegisterEvent("PLAYER_DIFFICULTY_CHANGED", "UpdateInstanceInfo") end
+	element:RegisterEvent("GUILD_PARTY_STATE_UPDATED", "UpdateGuildParty")
+	element:RegisterEvent("PLAYER_DIFFICULTY_CHANGED", "UpdateInstanceInfo")
 	element:RegisterEvent("INSTANCE_GROUP_SIZE_CHANGED", "UpdateInstanceInfo")
 	element:RegisterEvent("PLAYER_ENTERING_WORLD", "UpdateInstanceInfo")
-	if LUI.IsRetail then element:UpdateGuildParty() end
+	element:RegisterEvent("CHALLENGE_MODE_START", "UpdateInstanceInfo")
+	element:RegisterEvent("CHALLENGE_MODE_RESET", "UpdateInstanceInfo")
+	element:UpdateGuildParty()
 	element:UpdateInstanceInfo()
-
 	-- Update cached CVar data.
-	element:SecureHookScript(TimeManagerMilitaryTimeCheck, "OnClick", "UpdateCVar")
-	element:SecureHookScript(TimeManagerLocalTimeCheck, "OnClick", "UpdateCVar")
 	element:UpdateCVar()
-
-	if LUI.IsRetail then
-		-- Update calendar invites
-		element:RegisterEvent("CALENDAR_UPDATE_PENDING_INVITES", "UpdateInvites")
-		element:UpdateInvites()
+	element:RegisterEvent("CVAR_UPDATE")
+	if C_AddOns.IsAddOnLoaded("Blizzard_TimeManager") then
+		element:HookTimeManager()
+	else
+		element:RegisterEvent("ADDON_LOADED")
 	end
 
+	element:RegisterEvent("CALENDAR_UPDATE_PENDING_INVITES", "UpdateInvites")
+	element:UpdateInvites()
+
 	element:AddUpdate("UpdateClock", CLOCK_UPDATE_TIME)
+end
+
+function element:RefreshSettings()
+	element:UpdateInstanceFont()
+	element:UpdateInstanceInfo()
+	element:UpdateClock()
 end

--- a/modules/infotext/durability.lua
+++ b/modules/infotext/durability.lua
@@ -60,12 +60,20 @@ function element:UpdateDurability()
 	-- The first entry of the sorted table is the lowest value.
 	LUI:SortTable(sortedItems, itemDurability, itemSort)
 	local displayDur = (LUI:Count(itemDurability) > 0) and itemDurability[sortedItems[1]] * 100 or nil
-	element.text = format(L["InfoArmor_Display_Format"], displayDur or 100)
+	-- No readable durability is not the same as fully repaired equipment.
+	element.text = displayDur and format(L["InfoArmor_Display_Format"], displayDur)
+		or format("%s: --", ARMOR)
 	element:UpdateTooltip()
 end
 
 function element.OnClick(frame_, button_)
 	ToggleCharacter("PaperDollFrame")
+end
+
+function element:UNIT_INVENTORY_CHANGED(event, unit)
+	if unit == "player" then
+		self:UpdateDurability()
+	end
 end
 
 element.RefreshSettings = element.UpdateDurability
@@ -91,5 +99,7 @@ end
 
 function element:OnCreate()
 	element:RegisterEvent("UPDATE_INVENTORY_DURABILITY", "UpdateDurability")
+	element:RegisterEvent("PLAYER_ENTERING_WORLD", "UpdateDurability")
+	element:RegisterEvent("UNIT_INVENTORY_CHANGED")
 	element:UpdateDurability()
 end

--- a/modules/infotext/infotext.lua
+++ b/modules/infotext/infotext.lua
@@ -160,16 +160,16 @@ function module:SetInfoPanels()
 	topAnchor:Show()
 	module.topAnchor = topAnchor
 
+	module:RegisterLDBCallback("LibDataBroker_DataObjectCreated", "LDBDataObjectCreated")
+
 	-- Make sure all objects created before the callback gets properly initialized.
 	for name, element in LDB:DataObjectIterator() do
-		if not elementFrames[name] then
+		if not elementFrames[name] or not elementFrames[name].LUIInitialized then
 			self:DataObjectCreated(name, element)
 		else
 			module:RegisterLDBCallback("LibDataBroker_AttributeChanged_"..name, "AttributeChanged")
 		end
 	end
-
-	module:RegisterLDBCallback("LibDataBroker_DataObjectCreated", "LDBDataObjectCreated")
 end
 
 function module:NewElement(name, ...)
@@ -223,17 +223,20 @@ end
 -- ##### LDB Handling #################################################################################################
 -- ####################################################################################################################
 
---This is used on the creation of any LDB Object
-function module:DataObjectCreated(name, element)
+local function CreateDisplay(name, element)
 	if not supportedTypes[element.type] then return end
-	if elementFrames[name] then return end
+	local frame = elementFrames[name]
+	if frame and frame.LUIInitialized then return end
 
-	local frame = CreateFrame("Button", GetDisplayFrameName(name), module.topAnchor)
-	elementFrames[name] = frame
+	-- Reuse partial frames when settings are refreshed or the module is enabled again.
+	if not frame then
+		frame = CreateFrame("Button", GetDisplayFrameName(name), module.topAnchor)
+		elementFrames[name] = frame
+	end
 	frame.name = name
 	frame.element = element
 
-	frame.text = module:SetFontString(frame, frame:GetName().."Text", "Infotext", "OVERLAY", "LEFT", "MIDDLE")
+	frame.text = frame.text or module:SetFontString(frame, frame:GetName().."Text", "Infotext", "OVERLAY", "LEFT", "MIDDLE")
 	frame.text:SetAllPoints(frame)
 	local color = db[name].Color
 	frame.text:SetTextColor(color.r, color.g, color.b, color.a)
@@ -246,8 +249,11 @@ function module:DataObjectCreated(name, element)
 	frame:SetScript("OnLeave", module.OnLeaveHandler)
 
 	--Do some element based stuff here
-	if elementStorage[name] then LUI:EmbedModule(element) end
-	if element.OnCreate then element:OnCreate(frame) end
+	if not frame.LUIOnCreateComplete then
+		if elementStorage[name] then LUI:EmbedModule(element) end
+		if element.OnCreate then element:OnCreate(frame) end
+		frame.LUIOnCreateComplete = true
+	end
 
 	module:SetPosition(name, frame)
 
@@ -262,6 +268,22 @@ function module:DataObjectCreated(name, element)
 
 	--This allow me to unregister callbacks based on element instead of filtering using the global one.
 	module:RegisterLDBCallback("LibDataBroker_AttributeChanged_"..name, "AttributeChanged")
+	frame.LUIInitialized = true
+end
+
+local function RunDisplayOperation(name, operation)
+	-- Keep the original error visible to WoW/BugGrabber without aborting other displays.
+	local ok = xpcall(operation, geterrorhandler())
+	if not ok then
+		local frame = elementFrames[name]
+		if frame then frame:Hide() end
+	end
+	return ok
+end
+
+-- This is used on the creation of any LDB object.
+function module:DataObjectCreated(name, element)
+	return RunDisplayOperation(name, function() CreateDisplay(name, element) end)
 end
 
 function module:LDBDataObjectCreated(_, name, element)
@@ -346,17 +368,23 @@ function module:Refresh()
 	table.sort(displayNames)
 	for _, name in ipairs(displayNames) do
 		local obj = elementFrames[name]
-		module:SetPosition(name, obj)
-		local color = db[name].Color
-		obj.text:SetTextColor(color.r, color.g, color.b, color.a)
-		local font = db.Fonts.Infotext
-		obj.text:SetFont(Media:Fetch("font", font.Name), font.Size, font.Flag)
-		UpdateDisplaySize(obj)
-		if obj.element.RefreshSettings then obj.element:RefreshSettings() end
-		if db[name].Enable then
-			obj:Show()
+		if not obj.LUIInitialized then
+			module:DataObjectCreated(name, obj.element)
 		else
-			obj:Hide()
+			RunDisplayOperation(name, function()
+				module:SetPosition(name, obj)
+				local color = db[name].Color
+				obj.text:SetTextColor(color.r, color.g, color.b, color.a)
+				local font = db.Fonts.Infotext
+				obj.text:SetFont(Media:Fetch("font", font.Name), font.Size, font.Flag)
+				UpdateDisplaySize(obj)
+				if obj.element.RefreshSettings then obj.element:RefreshSettings() end
+				if db[name].Enable then
+					obj:Show()
+				else
+					obj:Hide()
+				end
+			end)
 		end
 	end
 	if module.RefreshInfotips then module:RefreshInfotips() end

--- a/modules/unitframes/defaults/player.lua
+++ b/modules/unitframes/defaults/player.lua
@@ -195,6 +195,17 @@ module.defaults.profile.player = {
 				X = 0,
 				Y = 0
 			},
+			RaidGroupText = {
+				Enable = false,
+				Font = "Prototype",
+				IndividualColor = { r = 1, g = 1, b = 1 },
+				Outline = "",
+				Point = "BOTTOM",
+				RelativePoint = "TOP",
+				Size = 14,
+				X = 0,
+				Y = 5,
+			},
 			HealthText = {
 				Color = "Individual",
 				Enable = true,

--- a/modules/unitframes/defaults/raid.lua
+++ b/modules/unitframes/defaults/raid.lua
@@ -13,6 +13,14 @@ module.defaults.profile.raid = {
 			RelativePoint = "TOPLEFT",
 			Padding = 4,
 			GroupPadding = 4,
+			GroupLabel = {
+				Enable = true,
+				Font = "Prototype",
+				Size = 12,
+				Outline = "",
+				Color = { r = 1, g = 1, b = 1 },
+				Spacing = 6,
+			},
 			Border = {
 				Aggro = true,
 				Color = { r = 0, g = 0, b = 0, a = 1 },

--- a/modules/unitframes/layout/layout.lua
+++ b/modules/unitframes/layout/layout.lua
@@ -944,6 +944,39 @@ module.funcs = {
 	end,
 
 	--texts
+	RaidGroupText = function(self, unit, oufdb)
+		local settings = oufdb.RaidGroupText
+		if not settings then return end
+
+		local text = self.RaidGroupText
+		if not settings.Enable then
+			if text then
+				self:Untag(text)
+				text:SetText("")
+				text:Hide()
+			end
+			return
+		end
+
+		if not text then
+			text = SetFontString(self.Overlay, Media:Fetch("font", settings.Font), settings.Size, settings.Outline)
+			self.RaidGroupText = text
+		end
+		text:SetFont(Media:Fetch("font", settings.Font), settings.Size, settings.Outline)
+		text:SetTextColor(settings.IndividualColor.r, settings.IndividualColor.g, settings.IndividualColor.b)
+		text:ClearAllPoints()
+		text:SetPoint(settings.Point, self, settings.RelativePoint, settings.X, settings.Y)
+		if self.LUIPreview or module.previewStyleUnit then
+			self:Untag(text)
+			text:SetText(GROUP.." 3")
+		else
+			-- The conditional prefix disappears with the group number outside raids.
+			self:Tag(text, "["..GROUP.." $>lui:raidgroup]")
+			text:UpdateTag()
+		end
+		text:Show()
+	end,
+
 	Info = function(self, unit, oufdb)
 		if not self.Info then self.Info = SetFontString(self.Overlay, Media:Fetch("font", oufdb.NameText.Font), oufdb.NameText.Size, oufdb.NameText.Outline) end
 		self.Info:SetFont(Media:Fetch("font", oufdb.NameText.Font), oufdb.NameText.Size, oufdb.NameText.Outline)
@@ -2263,6 +2296,7 @@ local function SetStyle(self, unit, isSingle)
 		module.funcs.RaidInfo(self, unit, oufdb)
 	end
 
+	module.funcs.RaidGroupText(self, unit, oufdb)
 	module.funcs.HealthValue(self, unit, oufdb)
 	module.funcs.HealthPercent(self, unit, oufdb)
 	module.funcs.HealthMissing(self, unit, oufdb)

--- a/modules/unitframes/layout/tags.lua
+++ b/modules/unitframes/layout/tags.lua
@@ -31,6 +31,12 @@ local nameCache = {}
 local TagMethods = oUF.Tags.Methods
 local TagEvents = oUF.Tags.Events
 
+-- Always use the player's raid group, even while the frame displays a vehicle.
+TagEvents["lui:raidgroup"] = TagEvents.group
+TagMethods["lui:raidgroup"] = function()
+	return TagMethods.group("player")
+end
+
 local function utf8sub(string, i, dots)
 	local bytes = string:len()
 	if bytes <= i then

--- a/modules/unitframes/options/showhide.lua
+++ b/modules/unitframes/options/showhide.lua
@@ -241,6 +241,9 @@ local function ShowGroup(group)
 			frame:SetScale(1)
 			if group == "raid" then
 				PositionRaidFrame(frame, container, db, i)
+				if (i - 1) % 5 == 0 then
+					module:ConfigureRaidGroupLabel(frame, math.floor((i - 1) / 5) + 1, db.Width, "TOP", true)
+				end
 			else
 				PositionGroupFrame(frame, previous, db, i)
 			end

--- a/modules/unitframes/options/toggle.lua
+++ b/modules/unitframes/options/toggle.lua
@@ -73,6 +73,83 @@ local function GetOpposite(dir)
 	end
 end
 
+local raidLabelHeaders = {}
+local raidLabelMedia = LibStub("LibSharedMedia-3.0")
+
+local function UpdateRaidGroupLabelVisibility(header)
+	local label = header.LUIGroupLabel
+	if not label then return end
+	local settings = module.db.profile.raid.GroupLabel
+	local first = header:GetAttribute("child1")
+	label:SetShown(settings and settings.Enable and IsInRaid() and first and first:IsShown() or false)
+end
+
+-- Only text visibility changes on roster events; secure header layout stays untouched.
+local raidLabelEvents = CreateFrame("Frame")
+raidLabelEvents:RegisterEvent("GROUP_ROSTER_UPDATE")
+raidLabelEvents:RegisterEvent("PLAYER_ENTERING_WORLD")
+raidLabelEvents:SetScript("OnEvent", function()
+	C_Timer.After(0, function()
+		for header in pairs(raidLabelHeaders) do
+			UpdateRaidGroupLabelVisibility(header)
+		end
+	end)
+end)
+
+function module:ConfigureRaidGroupLabel(anchor, group, width, point, preview)
+	local settings = self.db.profile.raid.GroupLabel
+	local label = anchor.LUIGroupLabel
+	if not settings or not settings.Enable then
+		if label then label:Hide() end
+		return
+	end
+	if not label then
+		label = anchor:CreateFontString(nil, "OVERLAY")
+		anchor.LUIGroupLabel = label
+		label:SetWordWrap(false)
+		label:SetNonSpaceWrap(false)
+		label:SetJustifyH("CENTER")
+		label:SetShadowColor(0, 0, 0, 1)
+		label:SetShadowOffset(1, -1)
+		if not preview then
+			raidLabelHeaders[anchor] = true
+			anchor:HookScript("OnShow", function(header)
+				C_Timer.After(0, function() UpdateRaidGroupLabelVisibility(header) end)
+			end)
+		end
+	end
+
+	label:SetFont(raidLabelMedia:Fetch("font", settings.Font), settings.Size, settings.Outline)
+	label:SetTextColor(settings.Color.r, settings.Color.g, settings.Color.b)
+	label:SetText(GROUP.." "..group)
+	label:SetWidth(0)
+	-- Fit the complete heading to narrow 40-player columns without overlapping its neighbour.
+	local textWidth = label:GetStringWidth()
+	if textWidth > width and width > 0 then
+		label:SetFont(raidLabelMedia:Fetch("font", settings.Font), settings.Size * width / textWidth, settings.Outline)
+	end
+	label:SetWidth(width)
+	label:ClearAllPoints()
+	local topOverflow, bottomOverflow = self.GetUnitFrameVerticalOverflow(self.db.profile.raid)
+	local spacing = settings.Spacing
+	-- Header point is the edge from which its children grow, not the screen anchor.
+	point = point or "TOP"
+	if point:find("TOP") then
+		label:SetPoint("BOTTOM", anchor, "TOP", 0, spacing + topOverflow)
+	elseif point:find("BOTTOM") then
+		label:SetPoint("TOP", anchor, "BOTTOM", 0, -spacing - bottomOverflow)
+	elseif point == "LEFT" then
+		label:SetPoint("RIGHT", anchor, "LEFT", -spacing, 0)
+	else
+		label:SetPoint("LEFT", anchor, "RIGHT", spacing, 0)
+	end
+	if preview then
+		label:Show()
+	else
+		UpdateRaidGroupLabelVisibility(anchor)
+	end
+end
+
 local pendingUnitToggles = {}
 local pendingToggleFrame = CreateFrame("Frame")
 
@@ -863,6 +940,15 @@ module.ToggleUnit = setmetatable({
 				end
 			end
 
+			for _, size in ipairs({25, 40}) do
+				local count = size == 25 and 5 or 8
+				local width = size == 25 and dbUnit.Width or (5 * dbUnit.Width - 3 * dbUnit.GroupPadding) / 8
+				for group = 1, count do
+					local header = _G["oUF_LUI_raid_"..size.."_"..group]
+					module:ConfigureRaidGroupLabel(header, group, width, header:GetAttribute("point"))
+				end
+			end
+
 		else
 			if oUF_LUI_raid then
 				for i = 1, 5 do
@@ -945,6 +1031,7 @@ module.ApplySettings = function(unit, force)
 				module.funcs.Info(frame, styleUnit, dbUnit)
 			end
 
+			module.funcs.RaidGroupText(frame, styleUnit, dbUnit)
 			module.funcs.HealthValue(frame, styleUnit, dbUnit)
 			module.funcs.HealthPercent(frame, styleUnit, dbUnit)
 			module.funcs.HealthMissing(frame, styleUnit, dbUnit)


### PR DESCRIPTION
Fix bag and item border textures, thickness and colors, including equipped bag slots. Keep backgrounds beneath item icons, apply correct quality colors and remove borders from empty slots.
Add stable bottom-fill sorting, refresh bag settings when switching profiles and restore gold separators.
Restore optional LUI styling for character and Warband banks using Blizzard's current bank system. Include adjustable layout, spacing between column pairs and independent bottom-fill options. Keep native bank controls and restore Blizzard's appearance when disabled.
Correct bank footer sizing and tab-icon highlighting, and update the v2609 changelog with the new bag and bank changes.